### PR TITLE
Support Nova 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.4||^8.0",
-        "laravel/framework": "^9.0|^10.0|^11.0",
-        "laravel/nova": "^4.0"
+        "php": "^8.1",
+        "laravel/framework": "^10.0 || ^11.0",
+        "laravel/nova": "^4.0 || ^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Plus drop PHP 7.4 and 8.0 support as Nova v5 has `"php": "^8.1",` req