### PR TITLE
Add PHPUnit test suite and CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,67 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [8.2, 8.3, 8.4, 8.5]
+        framework: [^12.0, ^13.0]
+        stability: [prefer-lowest, prefer-stable]
+        include:
+          - framework: ^12.0
+            testbench: 10.*
+            phpunit: ^11.5
+          - framework: ^13.0
+            testbench: 11.*
+            phpunit: ^11.5
+        exclude:
+          - php: 8.2
+            framework: ^13.0
+    name: P${{ matrix.php }} - L${{ matrix.framework }} - ${{ matrix.stability }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, libxml, mbstring, xml, xmlwriter, zip
+          coverage: none
+
+      - name: Add Nova credentials loaded from env
+        run: composer config http-basic.nova.laravel.com "${{ secrets.NOVA_USERNAME }}" "${{ secrets.NOVA_LICENSE_KEY }}"
+
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.framework }}" "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+
+      - name: Execute tests
+        run: vendor/bin/phpunit
+
+  tests-required:
+    name: Tests Required
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs:
+      - tests
+
+    steps:
+      - name: Verify test matrix completed successfully
+        run: |
+          if [ "${{ needs.tests.result }}" != "success" ]; then
+            echo "Test matrix result: ${{ needs.tests.result }}"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ composer.phar
 composer.lock
 phpunit.xml
 .phpunit.result.cache
+.phpunit.cache/
 .DS_Store
 Thumbs.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Included Pint & PHPStan static analysis
 - Create Github actions for static analysis
 - Update dependabot configuration
+- Added a PHPUnit and Testbench-based package test suite
+- Added a GitHub Actions test matrix for supported PHP 8.2+ and Laravel 12/13 versions
 
 ### Changed
 - Raised the minimum supported PHP version to 8.2

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
     "require-dev": {
         "larastan/larastan": "^3.9",
         "laravel/nova-devtool": "^1.1",
-        "laravel/pint": "^1.29"
+        "laravel/pint": "^1.29",
+        "orchestra/testbench": "^10.8|^11.0",
+        "phpunit/phpunit": "^11.5"
     },
     "repositories": [
         {
@@ -43,6 +45,7 @@
     "prefer-stable": true,
     "autoload-dev": {
         "psr-4": {
+            "Markwalet\\NovaModalResponse\\Tests\\": "tests/",
             "Workbench\\App\\": "workbench/app/",
             "Workbench\\Database\\Factories\\": "workbench/database/factories/",
             "Workbench\\Database\\Seeders\\": "workbench/database/seeders/"
@@ -56,6 +59,7 @@
         "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
         "prepare": "@php vendor/bin/testbench package:discover --ansi",
         "build": "@php vendor/bin/testbench workbench:build --ansi",
+        "test": "@php vendor/bin/phpunit",
         "serve": [
             "Composer\\Config::disableProcessTimeout",
             "@build",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         colors="true">
+    <testsuites>
+        <testsuite name="Feature">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/AssetServiceProviderTest.php
+++ b/tests/AssetServiceProviderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Tests;
+
+use Illuminate\Http\Request;
+use Laravel\Nova\Events\ServingNova;
+use Laravel\Nova\Nova;
+
+class AssetServiceProviderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Nova::$scripts = [];
+        Nova::$styles = [];
+    }
+
+    public function test_assets_are_registered_when_nova_is_serving(): void
+    {
+        ServingNova::dispatch($this->app, Request::create('/nova', 'GET'));
+
+        $packageRoot = dirname(__DIR__);
+
+        $this->assertCount(1, Nova::allScripts());
+        $this->assertCount(1, Nova::allStyles());
+        $this->assertSame('nova-modal-response', Nova::allScripts()[0]->name());
+        $this->assertSame($packageRoot.'/dist/js/asset.js', realpath(Nova::allScripts()[0]->path()));
+        $this->assertSame('nova-modal-response', Nova::allStyles()[0]->name());
+        $this->assertSame($packageRoot.'/dist/css/asset.css', realpath(Nova::allStyles()[0]->path()));
+    }
+}

--- a/tests/ModalResponseTest.php
+++ b/tests/ModalResponseTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Tests;
+
+use JsonException;
+use Laravel\Nova\Actions\Responses\Modal;
+use Markwalet\NovaModalResponse\ModalResponse;
+
+class ModalResponseTest extends TestCase
+{
+    public function test_code_response_builds_the_expected_modal_payload(): void
+    {
+        $response = ModalResponse::code('echo "test";')
+            ->title('Snippet')
+            ->size('7xl')
+            ->withoutSyntaxHighlighting()
+            ->closeButton('Done');
+
+        $modal = $response['modal'];
+
+        $this->assertInstanceOf(Modal::class, $modal);
+        $this->assertSame('modal-response', $modal->component);
+        $this->assertSame([
+            'code' => 'echo "test";',
+            'title' => 'Snippet',
+            'size' => '7xl',
+            'highlight' => false,
+            'closeButtonText' => 'Done',
+        ], $modal->payload);
+    }
+
+    public function test_json_response_pretty_prints_the_payload(): void
+    {
+        $response = ModalResponse::json([
+            'lorem' => 'ipsum',
+            'dolor' => ['sit', 'amet'],
+        ]);
+
+        $modal = $response['modal'];
+
+        $this->assertInstanceOf(Modal::class, $modal);
+        $this->assertSame([
+            'code' => json_encode([
+                'lorem' => 'ipsum',
+                'dolor' => ['sit', 'amet'],
+            ], JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR),
+        ], $modal->payload);
+    }
+
+    public function test_json_response_throws_for_invalid_utf8(): void
+    {
+        $this->expectException(JsonException::class);
+
+        ModalResponse::json([
+            'invalid' => "\xB1\x31",
+        ]);
+    }
+
+    public function test_text_and_html_responses_use_the_expected_payload_keys(): void
+    {
+        $textResponse = ModalResponse::text('Plain text');
+        $htmlResponse = ModalResponse::html('<strong>HTML</strong>');
+
+        $this->assertSame([
+            'body' => 'Plain text',
+        ], $textResponse['modal']->payload);
+
+        $this->assertSame([
+            'html' => '<strong>HTML</strong>',
+        ], $htmlResponse['modal']->payload);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Tests;
+
+use Markwalet\NovaModalResponse\AssetServiceProvider;
+use Orchestra\Testbench\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    /**
+     * @return array<int, class-string>
+     */
+    protected function getPackageProviders($app): array
+    {
+        return [
+            AssetServiceProvider::class,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add a PHPUnit/Testbench-based package test suite for ModalResponse and asset registration
- add a GitHub Actions test workflow covering the supported PHP 8.2+ and Laravel 12/13 matrix
- wire in PHPUnit config, a composer test script, and changelog updates for the new test coverage

## Why
This package had static analysis but no automated runtime test coverage. This PR adds a low-friction package test suite and CI coverage that matches the current supported version constraints after rebasing onto main.