### PR TITLE
v2 #28: divider block

### DIFF
--- a/resources/js/asset.js
+++ b/resources/js/asset.js
@@ -1,7 +1,9 @@
 import ModalActionResponse from './components/ModalActionResponse'
 import TextBlock from './components/TextBlock'
+import DividerBlock from './components/DividerBlock'
 
 Nova.booting(app => {
     app.component('modal-response', ModalActionResponse)
     app.component('modal-response-text-block', TextBlock)
+    app.component('modal-response-divider-block', DividerBlock)
 });

--- a/resources/js/components/DividerBlock.vue
+++ b/resources/js/components/DividerBlock.vue
@@ -1,0 +1,13 @@
+<template>
+    <div class="py-3 px-8">
+        <hr class="border-t border-gray-200 dark:border-gray-700" />
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        block: { type: Object, required: true },
+    },
+}
+</script>

--- a/resources/js/components/ModalActionResponse.vue
+++ b/resources/js/components/ModalActionResponse.vue
@@ -35,6 +35,7 @@
 <script>
 import { Button } from 'laravel-nova-ui'
 import TextBlock from './TextBlock.vue'
+import DividerBlock from './DividerBlock.vue'
 
 export default {
     components: {
@@ -52,6 +53,7 @@ export default {
         return {
             blockComponents: {
                 text: TextBlock,
+                divider: DividerBlock,
             },
         }
     },

--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -15,4 +15,9 @@ abstract class Block
     {
         return new TextBlock($value);
     }
+
+    public static function divider(): DividerBlock
+    {
+        return new DividerBlock;
+    }
 }

--- a/src/Blocks/DividerBlock.php
+++ b/src/Blocks/DividerBlock.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Blocks;
+
+class DividerBlock extends Block
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return ['type' => 'divider'];
+    }
+}

--- a/tests/Blocks/DividerBlockTest.php
+++ b/tests/Blocks/DividerBlockTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Tests\Blocks;
+
+use Markwalet\NovaModalResponse\Blocks\Block;
+use Markwalet\NovaModalResponse\Blocks\DividerBlock;
+use Markwalet\NovaModalResponse\Tests\TestCase;
+
+class DividerBlockTest extends TestCase
+{
+    public function test_it_serialises_to_a_typed_divider_block(): void
+    {
+        $block = new DividerBlock;
+
+        $this->assertSame(['type' => 'divider'], $block->toArray());
+    }
+
+    public function test_factory_returns_a_divider_block(): void
+    {
+        $this->assertInstanceOf(DividerBlock::class, Block::divider());
+    }
+}


### PR DESCRIPTION
Closes #28.

## Summary
- New `DividerBlock` with `Block::divider()` factory; `toArray()` returns `['type' => 'divider']`.
- New `DividerBlock.vue` registered as `modal-response-divider-block` and wired into the dispatcher.

## Test plan
- [x] `vendor/bin/phpunit` — green
- [x] `vendor/bin/pint --test` — clean
- [x] `vendor/bin/phpstan analyse` — clean
- [ ] Workbench: divider visibly separates two adjacent blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)