### PR TITLE
v2 #25: html block + ModalResponse::html() sugar

### DIFF
--- a/resources/js/asset.js
+++ b/resources/js/asset.js
@@ -1,9 +1,11 @@
 import ModalActionResponse from './components/ModalActionResponse'
 import TextBlock from './components/TextBlock'
 import DividerBlock from './components/DividerBlock'
+import HtmlBlock from './components/HtmlBlock'
 
 Nova.booting(app => {
     app.component('modal-response', ModalActionResponse)
     app.component('modal-response-text-block', TextBlock)
     app.component('modal-response-divider-block', DividerBlock)
+    app.component('modal-response-html-block', HtmlBlock)
 });

--- a/resources/js/components/HtmlBlock.vue
+++ b/resources/js/components/HtmlBlock.vue
@@ -1,0 +1,11 @@
+<template>
+    <div class="py-3 px-8" v-html="block.value" />
+</template>
+
+<script>
+export default {
+    props: {
+        block: { type: Object, required: true },
+    },
+}
+</script>

--- a/resources/js/components/ModalActionResponse.vue
+++ b/resources/js/components/ModalActionResponse.vue
@@ -36,6 +36,7 @@
 import { Button } from 'laravel-nova-ui'
 import TextBlock from './TextBlock.vue'
 import DividerBlock from './DividerBlock.vue'
+import HtmlBlock from './HtmlBlock.vue'
 
 export default {
     components: {
@@ -54,6 +55,7 @@ export default {
             blockComponents: {
                 text: TextBlock,
                 divider: DividerBlock,
+                html: HtmlBlock,
             },
         }
     },

--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -20,4 +20,9 @@ abstract class Block
     {
         return new DividerBlock;
     }
+
+    public static function html(string|Stringable $value): HtmlBlock
+    {
+        return new HtmlBlock($value);
+    }
 }

--- a/src/Blocks/HtmlBlock.php
+++ b/src/Blocks/HtmlBlock.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Blocks;
+
+use Illuminate\Support\Stringable;
+
+class HtmlBlock extends Block
+{
+    public function __construct(private readonly string|Stringable $value) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => 'html',
+            'value' => (string) $this->value,
+        ];
+    }
+}

--- a/src/ModalResponse.php
+++ b/src/ModalResponse.php
@@ -47,6 +47,11 @@ class ModalResponse extends ActionResponse
         return self::stack([Block::text($value)]);
     }
 
+    public static function html(string|Stringable $value): self
+    {
+        return self::stack([Block::html($value)]);
+    }
+
     public function title(string $title): self
     {
         return $this->setChrome('title', $title);

--- a/tests/Blocks/HtmlBlockTest.php
+++ b/tests/Blocks/HtmlBlockTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Tests\Blocks;
+
+use Markwalet\NovaModalResponse\Blocks\Block;
+use Markwalet\NovaModalResponse\Blocks\HtmlBlock;
+use Markwalet\NovaModalResponse\ModalResponse;
+use Markwalet\NovaModalResponse\Tests\TestCase;
+
+class HtmlBlockTest extends TestCase
+{
+    public function test_it_serialises_to_a_typed_html_block(): void
+    {
+        $block = new HtmlBlock('<b>hi</b>');
+
+        $this->assertSame(
+            ['type' => 'html', 'value' => '<b>hi</b>'],
+            $block->toArray(),
+        );
+    }
+
+    public function test_factory_returns_an_html_block(): void
+    {
+        $this->assertInstanceOf(HtmlBlock::class, Block::html('<b>x</b>'));
+    }
+
+    public function test_html_sugar_produces_a_single_html_block_stack(): void
+    {
+        $response = ModalResponse::html('<b>hi</b>');
+
+        $this->assertSame([
+            'blocks' => [
+                ['type' => 'html', 'value' => '<b>hi</b>'],
+            ],
+        ], $response['modal']->payload);
+    }
+}


### PR DESCRIPTION
Closes #25.

## Summary
- New `HtmlBlock` with `Block::html()` factory; `toArray()` returns `['type' => 'html', 'value' => ...]`.
- Restored `ModalResponse::html()` one-liner sugar over `stack([Block::html(...)])`.
- `HtmlBlock.vue` renders via `v-html` (no sanitization, matches v1).

## Test plan
- [x] PHP unit tests green; pint + phpstan clean
- [ ] Workbench: html block renders raw markup

🤖 Generated with [Claude Code](https://claude.com/claude-code)