### PR TITLE
v2 #26: heading block with visual sizes

### DIFF
--- a/resources/js/asset.js
+++ b/resources/js/asset.js
@@ -2,10 +2,12 @@ import ModalActionResponse from './components/ModalActionResponse'
 import TextBlock from './components/TextBlock'
 import DividerBlock from './components/DividerBlock'
 import HtmlBlock from './components/HtmlBlock'
+import HeadingBlock from './components/HeadingBlock'
 
 Nova.booting(app => {
     app.component('modal-response', ModalActionResponse)
     app.component('modal-response-text-block', TextBlock)
     app.component('modal-response-divider-block', DividerBlock)
     app.component('modal-response-html-block', HtmlBlock)
+    app.component('modal-response-heading-block', HeadingBlock)
 });

--- a/resources/js/components/HeadingBlock.vue
+++ b/resources/js/components/HeadingBlock.vue
@@ -1,0 +1,25 @@
+<template>
+    <div class="py-3 px-8">
+        <div :class="sizeClass" v-text="block.value" />
+    </div>
+</template>
+
+<script>
+const SIZE_CLASSES = {
+    small: 'text-sm font-semibold',
+    medium: 'text-base font-semibold',
+    large: 'text-lg font-bold',
+}
+
+export default {
+    props: {
+        block: { type: Object, required: true },
+    },
+
+    computed: {
+        sizeClass() {
+            return SIZE_CLASSES[this.block.size] ?? SIZE_CLASSES.medium
+        },
+    },
+}
+</script>

--- a/resources/js/components/ModalActionResponse.vue
+++ b/resources/js/components/ModalActionResponse.vue
@@ -37,6 +37,7 @@ import { Button } from 'laravel-nova-ui'
 import TextBlock from './TextBlock.vue'
 import DividerBlock from './DividerBlock.vue'
 import HtmlBlock from './HtmlBlock.vue'
+import HeadingBlock from './HeadingBlock.vue'
 
 export default {
     components: {
@@ -56,6 +57,7 @@ export default {
                 text: TextBlock,
                 divider: DividerBlock,
                 html: HtmlBlock,
+                heading: HeadingBlock,
             },
         }
     },

--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -25,4 +25,9 @@ abstract class Block
     {
         return new HtmlBlock($value);
     }
+
+    public static function heading(string|Stringable $value): HeadingBlock
+    {
+        return new HeadingBlock($value);
+    }
 }

--- a/src/Blocks/HeadingBlock.php
+++ b/src/Blocks/HeadingBlock.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Blocks;
+
+use Illuminate\Support\Stringable;
+
+class HeadingBlock extends Block
+{
+    private string $size = 'medium';
+
+    public function __construct(private readonly string|Stringable $value) {}
+
+    public function small(): self
+    {
+        $this->size = 'small';
+
+        return $this;
+    }
+
+    public function medium(): self
+    {
+        $this->size = 'medium';
+
+        return $this;
+    }
+
+    public function large(): self
+    {
+        $this->size = 'large';
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => 'heading',
+            'value' => (string) $this->value,
+            'size' => $this->size,
+        ];
+    }
+}

--- a/tests/Blocks/HeadingBlockTest.php
+++ b/tests/Blocks/HeadingBlockTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Tests\Blocks;
+
+use Markwalet\NovaModalResponse\Blocks\Block;
+use Markwalet\NovaModalResponse\Blocks\HeadingBlock;
+use Markwalet\NovaModalResponse\Tests\TestCase;
+
+class HeadingBlockTest extends TestCase
+{
+    public function test_factory_returns_a_heading_block_with_default_medium_size(): void
+    {
+        $block = Block::heading('Result');
+
+        $this->assertInstanceOf(HeadingBlock::class, $block);
+        $this->assertSame(
+            ['type' => 'heading', 'value' => 'Result', 'size' => 'medium'],
+            $block->toArray(),
+        );
+    }
+
+    public function test_small_sets_size_to_small(): void
+    {
+        $this->assertSame(
+            ['type' => 'heading', 'value' => 'x', 'size' => 'small'],
+            Block::heading('x')->small()->toArray(),
+        );
+    }
+
+    public function test_medium_sets_size_to_medium(): void
+    {
+        $this->assertSame(
+            ['type' => 'heading', 'value' => 'x', 'size' => 'medium'],
+            Block::heading('x')->large()->medium()->toArray(),
+        );
+    }
+
+    public function test_large_sets_size_to_large(): void
+    {
+        $this->assertSame(
+            ['type' => 'heading', 'value' => 'x', 'size' => 'large'],
+            Block::heading('x')->large()->toArray(),
+        );
+    }
+}


### PR DESCRIPTION
Closes #26. Stacked on top of #34 (#25 html).

## Summary
- New `HeadingBlock` with `Block::heading()` factory; default size `medium`.
- Fluent `->small()`, `->medium()`, `->large()` set the visual size.
- `HeadingBlock.vue` renders three distinct sizes via class binding; deliberately no `<h1>`-`<h6>` tags.

## Test plan
- [x] PHP unit tests green; pint + phpstan clean
- [ ] Workbench: three sizes render visibly distinct

🤖 Generated with [Claude Code](https://claude.com/claude-code)