### PR TITLE
v2 #29: list block (ordered / unordered, strings only)

### DIFF
--- a/resources/js/asset.js
+++ b/resources/js/asset.js
@@ -3,6 +3,7 @@ import TextBlock from './components/TextBlock'
 import DividerBlock from './components/DividerBlock'
 import HtmlBlock from './components/HtmlBlock'
 import HeadingBlock from './components/HeadingBlock'
+import ListBlock from './components/ListBlock'
 
 Nova.booting(app => {
     app.component('modal-response', ModalActionResponse)
@@ -10,4 +11,5 @@ Nova.booting(app => {
     app.component('modal-response-divider-block', DividerBlock)
     app.component('modal-response-html-block', HtmlBlock)
     app.component('modal-response-heading-block', HeadingBlock)
+    app.component('modal-response-list-block', ListBlock)
 });

--- a/resources/js/components/ListBlock.vue
+++ b/resources/js/components/ListBlock.vue
@@ -1,0 +1,17 @@
+<template>
+    <div class="py-3 px-8">
+        <component :is="block.ordered ? 'ol' : 'ul'"
+                   :class="block.ordered ? 'list-decimal' : 'list-disc'"
+                   class="pl-6 space-y-1">
+            <li v-for="(item, index) in block.value" :key="index" v-text="item" />
+        </component>
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        block: { type: Object, required: true },
+    },
+}
+</script>

--- a/resources/js/components/ModalActionResponse.vue
+++ b/resources/js/components/ModalActionResponse.vue
@@ -38,6 +38,7 @@ import TextBlock from './TextBlock.vue'
 import DividerBlock from './DividerBlock.vue'
 import HtmlBlock from './HtmlBlock.vue'
 import HeadingBlock from './HeadingBlock.vue'
+import ListBlock from './ListBlock.vue'
 
 export default {
     components: {
@@ -58,6 +59,7 @@ export default {
                 divider: DividerBlock,
                 html: HtmlBlock,
                 heading: HeadingBlock,
+                list: ListBlock,
             },
         }
     },

--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -30,4 +30,12 @@ abstract class Block
     {
         return new HeadingBlock($value);
     }
+
+    /**
+     * @param array<int, string|\Stringable> $items
+     */
+    public static function list(array $items): ListBlock
+    {
+        return new ListBlock($items);
+    }
 }

--- a/src/Blocks/ListBlock.php
+++ b/src/Blocks/ListBlock.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Blocks;
+
+use Stringable;
+
+class ListBlock extends Block
+{
+    private bool $ordered = false;
+
+    /**
+     * @param array<int, string|Stringable> $items
+     */
+    public function __construct(private readonly array $items) {}
+
+    public function ordered(): self
+    {
+        $this->ordered = true;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => 'list',
+            'value' => array_map(static fn (string|Stringable $item): string => (string) $item, $this->items),
+            'ordered' => $this->ordered,
+        ];
+    }
+}

--- a/tests/Blocks/ListBlockTest.php
+++ b/tests/Blocks/ListBlockTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Tests\Blocks;
+
+use Illuminate\Support\Stringable;
+use Markwalet\NovaModalResponse\Blocks\Block;
+use Markwalet\NovaModalResponse\Blocks\ListBlock;
+use Markwalet\NovaModalResponse\Tests\TestCase;
+
+class ListBlockTest extends TestCase
+{
+    public function test_factory_returns_an_unordered_list_block_by_default(): void
+    {
+        $block = Block::list(['a', 'b']);
+
+        $this->assertInstanceOf(ListBlock::class, $block);
+        $this->assertSame(
+            ['type' => 'list', 'value' => ['a', 'b'], 'ordered' => false],
+            $block->toArray(),
+        );
+    }
+
+    public function test_ordered_flips_the_style(): void
+    {
+        $this->assertSame(
+            ['type' => 'list', 'value' => ['a', 'b'], 'ordered' => true],
+            Block::list(['a', 'b'])->ordered()->toArray(),
+        );
+    }
+
+    public function test_stringable_items_are_coerced_to_strings(): void
+    {
+        $this->assertSame(
+            ['type' => 'list', 'value' => ['a', 'b'], 'ordered' => false],
+            Block::list(['a', new Stringable('b')])->toArray(),
+        );
+    }
+}


### PR DESCRIPTION
Closes #29. Stacked on top of #35 (#26 heading).

## Summary
- New `ListBlock` accepting `array<string|Stringable>`; `Block::list([...])` factory; default unordered, `->ordered()` flips.
- `toArray()` returns `['type' => 'list', 'value' => [...], 'ordered' => bool]`.
- `ListBlock.vue` renders `<ul>`/`<ol>` based on `ordered` flag.

## Test plan
- [x] PHP unit tests green; pint + phpstan clean
- [ ] Workbench: ordered and unordered render with expected markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)