### PR TITLE
v2 #27: badge block with five variants

### DIFF
--- a/resources/js/asset.js
+++ b/resources/js/asset.js
@@ -4,6 +4,7 @@ import DividerBlock from './components/DividerBlock'
 import HtmlBlock from './components/HtmlBlock'
 import HeadingBlock from './components/HeadingBlock'
 import ListBlock from './components/ListBlock'
+import BadgeBlock from './components/BadgeBlock'
 
 Nova.booting(app => {
     app.component('modal-response', ModalActionResponse)
@@ -12,4 +13,5 @@ Nova.booting(app => {
     app.component('modal-response-html-block', HtmlBlock)
     app.component('modal-response-heading-block', HeadingBlock)
     app.component('modal-response-list-block', ListBlock)
+    app.component('modal-response-badge-block', BadgeBlock)
 });

--- a/resources/js/components/BadgeBlock.vue
+++ b/resources/js/components/BadgeBlock.vue
@@ -1,0 +1,29 @@
+<template>
+    <div class="py-3 px-8">
+        <span :class="variantClass"
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold"
+              v-text="block.value" />
+    </div>
+</template>
+
+<script>
+const VARIANT_CLASSES = {
+    default: 'bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-200',
+    info: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+    success: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+    warning: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+    danger: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+}
+
+export default {
+    props: {
+        block: { type: Object, required: true },
+    },
+
+    computed: {
+        variantClass() {
+            return VARIANT_CLASSES[this.block.variant] ?? VARIANT_CLASSES.default
+        },
+    },
+}
+</script>

--- a/resources/js/components/ModalActionResponse.vue
+++ b/resources/js/components/ModalActionResponse.vue
@@ -39,6 +39,7 @@ import DividerBlock from './DividerBlock.vue'
 import HtmlBlock from './HtmlBlock.vue'
 import HeadingBlock from './HeadingBlock.vue'
 import ListBlock from './ListBlock.vue'
+import BadgeBlock from './BadgeBlock.vue'
 
 export default {
     components: {
@@ -60,6 +61,7 @@ export default {
                 html: HtmlBlock,
                 heading: HeadingBlock,
                 list: ListBlock,
+                badge: BadgeBlock,
             },
         }
     },

--- a/src/Blocks/BadgeBlock.php
+++ b/src/Blocks/BadgeBlock.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Blocks;
+
+use Illuminate\Support\Stringable;
+
+class BadgeBlock extends Block
+{
+    private string $variant = 'default';
+
+    public function __construct(private readonly string|Stringable $value) {}
+
+    public function default(): self
+    {
+        return $this->setVariant('default');
+    }
+
+    public function info(): self
+    {
+        return $this->setVariant('info');
+    }
+
+    public function success(): self
+    {
+        return $this->setVariant('success');
+    }
+
+    public function warning(): self
+    {
+        return $this->setVariant('warning');
+    }
+
+    public function danger(): self
+    {
+        return $this->setVariant('danger');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => 'badge',
+            'value' => (string) $this->value,
+            'variant' => $this->variant,
+        ];
+    }
+
+    private function setVariant(string $variant): self
+    {
+        $this->variant = $variant;
+
+        return $this;
+    }
+}

--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -38,4 +38,9 @@ abstract class Block
     {
         return new ListBlock($items);
     }
+
+    public static function badge(string|Stringable $value): BadgeBlock
+    {
+        return new BadgeBlock($value);
+    }
 }

--- a/tests/Blocks/BadgeBlockTest.php
+++ b/tests/Blocks/BadgeBlockTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Tests\Blocks;
+
+use Markwalet\NovaModalResponse\Blocks\BadgeBlock;
+use Markwalet\NovaModalResponse\Blocks\Block;
+use Markwalet\NovaModalResponse\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class BadgeBlockTest extends TestCase
+{
+    public function test_factory_returns_a_badge_with_default_variant(): void
+    {
+        $block = Block::badge('New');
+
+        $this->assertInstanceOf(BadgeBlock::class, $block);
+        $this->assertSame(
+            ['type' => 'badge', 'value' => 'New', 'variant' => 'default'],
+            $block->toArray(),
+        );
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function variantProvider(): array
+    {
+        return [
+            'default' => ['default'],
+            'info' => ['info'],
+            'success' => ['success'],
+            'warning' => ['warning'],
+            'danger' => ['danger'],
+        ];
+    }
+
+    #[DataProvider('variantProvider')]
+    public function test_each_variant_method_sets_the_variant(string $variant): void
+    {
+        $this->assertSame(
+            ['type' => 'badge', 'value' => 'x', 'variant' => $variant],
+            Block::badge('x')->{$variant}()->toArray(),
+        );
+    }
+}


### PR DESCRIPTION
Closes #27. Stacked on top of #36 (#29 list).

## Summary
- New `BadgeBlock` with `Block::badge()` factory; default variant `default`.
- Fluent `->default()` / `->info()` / `->success()` / `->warning()` / `->danger()` set the variant.
- `BadgeBlock.vue` renders distinct colours per variant.

## Test plan
- [x] PHP unit tests green (incl. data-provider over 5 variants); pint + phpstan clean
- [ ] Workbench: five badges render with distinct colours

🤖 Generated with [Claude Code](https://claude.com/claude-code)