### PR TITLE
v2 #23: code block + restore ModalResponse::code() sugar

### DIFF
--- a/resources/js/asset.js
+++ b/resources/js/asset.js
@@ -5,6 +5,7 @@ import HtmlBlock from './components/HtmlBlock'
 import HeadingBlock from './components/HeadingBlock'
 import ListBlock from './components/ListBlock'
 import BadgeBlock from './components/BadgeBlock'
+import CodeBlock from './components/CodeBlock'
 
 Nova.booting(app => {
     app.component('modal-response', ModalActionResponse)
@@ -14,4 +15,5 @@ Nova.booting(app => {
     app.component('modal-response-heading-block', HeadingBlock)
     app.component('modal-response-list-block', ListBlock)
     app.component('modal-response-badge-block', BadgeBlock)
+    app.component('modal-response-code-block', CodeBlock)
 });

--- a/resources/js/components/CodeBlock.vue
+++ b/resources/js/components/CodeBlock.vue
@@ -1,0 +1,28 @@
+<template>
+    <template v-if="block.highlight === false">
+        <pre><code ref="plaintextCode" class="language-plaintext" v-text="block.value" /></pre>
+    </template>
+    <highlightjs v-else-if="block.language" :language="block.language" :code="block.value" />
+    <highlightjs v-else autodetect :code="block.value" />
+</template>
+
+<script>
+import hljs from 'highlight.js/lib/common'
+import hljsVuePlugin from '@highlightjs/vue-plugin'
+
+export default {
+    components: {
+        highlightjs: hljsVuePlugin.component,
+    },
+
+    props: {
+        block: { type: Object, required: true },
+    },
+
+    mounted() {
+        if (this.block.highlight === false && this.$refs.plaintextCode) {
+            hljs.highlightElement(this.$refs.plaintextCode)
+        }
+    },
+}
+</script>

--- a/resources/js/components/ModalActionResponse.vue
+++ b/resources/js/components/ModalActionResponse.vue
@@ -40,6 +40,7 @@ import HtmlBlock from './HtmlBlock.vue'
 import HeadingBlock from './HeadingBlock.vue'
 import ListBlock from './ListBlock.vue'
 import BadgeBlock from './BadgeBlock.vue'
+import CodeBlock from './CodeBlock.vue'
 
 export default {
     components: {
@@ -62,6 +63,7 @@ export default {
                 heading: HeadingBlock,
                 list: ListBlock,
                 badge: BadgeBlock,
+                code: CodeBlock,
             },
         }
     },

--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -43,4 +43,9 @@ abstract class Block
     {
         return new BadgeBlock($value);
     }
+
+    public static function code(string|Stringable $value): CodeBlock
+    {
+        return new CodeBlock($value);
+    }
 }

--- a/src/Blocks/CodeBlock.php
+++ b/src/Blocks/CodeBlock.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Blocks;
+
+use Illuminate\Support\Stringable;
+
+class CodeBlock extends Block
+{
+    private ?string $language = null;
+
+    private bool $highlight = true;
+
+    public function __construct(private readonly string|Stringable $value) {}
+
+    public function language(string $language): self
+    {
+        $this->language = $language;
+
+        return $this;
+    }
+
+    public function withoutHighlighting(): self
+    {
+        $this->highlight = false;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $payload = [
+            'type' => 'code',
+            'value' => (string) $this->value,
+            'highlight' => $this->highlight,
+        ];
+
+        if ($this->language !== null) {
+            $payload['language'] = $this->language;
+        }
+
+        return $payload;
+    }
+}

--- a/src/ModalResponse.php
+++ b/src/ModalResponse.php
@@ -52,6 +52,11 @@ class ModalResponse extends ActionResponse
         return self::stack([Block::html($value)]);
     }
 
+    public static function code(string|Stringable $value): self
+    {
+        return self::stack([Block::code($value)]);
+    }
+
     public function title(string $title): self
     {
         return $this->setChrome('title', $title);

--- a/tests/Blocks/CodeBlockTest.php
+++ b/tests/Blocks/CodeBlockTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Tests\Blocks;
+
+use Markwalet\NovaModalResponse\Blocks\Block;
+use Markwalet\NovaModalResponse\Blocks\CodeBlock;
+use Markwalet\NovaModalResponse\ModalResponse;
+use Markwalet\NovaModalResponse\Tests\TestCase;
+
+class CodeBlockTest extends TestCase
+{
+    public function test_factory_returns_a_code_block_with_highlight_autodetect(): void
+    {
+        $block = Block::code('echo 1;');
+
+        $this->assertInstanceOf(CodeBlock::class, $block);
+        $this->assertSame(
+            ['type' => 'code', 'value' => 'echo 1;', 'highlight' => true],
+            $block->toArray(),
+        );
+    }
+
+    public function test_language_sets_the_language_hint(): void
+    {
+        $this->assertSame(
+            ['type' => 'code', 'value' => 'x', 'highlight' => true, 'language' => 'php'],
+            Block::code('x')->language('php')->toArray(),
+        );
+    }
+
+    public function test_without_highlighting_disables_highlighting(): void
+    {
+        $this->assertSame(
+            ['type' => 'code', 'value' => 'x', 'highlight' => false],
+            Block::code('x')->withoutHighlighting()->toArray(),
+        );
+    }
+
+    public function test_code_sugar_produces_a_single_code_block_stack(): void
+    {
+        $response = ModalResponse::code('echo 1;');
+
+        $this->assertSame([
+            'blocks' => [
+                ['type' => 'code', 'value' => 'echo 1;', 'highlight' => true],
+            ],
+        ], $response['modal']->payload);
+    }
+}


### PR DESCRIPTION
Closes #23. Stacked on top of #37 (#27 badge).

## Summary
- New `CodeBlock` with `Block::code()` factory; `highlight: true` (autodetect) by default.
- `->language(string)` adds an explicit language hint; `->withoutHighlighting()` flips to plaintext.
- Restored `ModalResponse::code()` one-liner sugar.
- `CodeBlock.vue` owns highlight.js imports (no longer in `ModalActionResponse.vue`) and renders highlighted, language-hinted, or plaintext code.

## Test plan
- [x] PHP unit tests green; pint + phpstan clean
- [ ] Workbench: autodetect, `->language('sql')`, and `->withoutHighlighting()` all render as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)