### PR TITLE
v2 #24: json block + restore ModalResponse::json() sugar

### DIFF
--- a/resources/js/asset.js
+++ b/resources/js/asset.js
@@ -6,6 +6,7 @@ import HeadingBlock from './components/HeadingBlock'
 import ListBlock from './components/ListBlock'
 import BadgeBlock from './components/BadgeBlock'
 import CodeBlock from './components/CodeBlock'
+import JsonBlock from './components/JsonBlock'
 
 Nova.booting(app => {
     app.component('modal-response', ModalActionResponse)
@@ -16,4 +17,5 @@ Nova.booting(app => {
     app.component('modal-response-list-block', ListBlock)
     app.component('modal-response-badge-block', BadgeBlock)
     app.component('modal-response-code-block', CodeBlock)
+    app.component('modal-response-json-block', JsonBlock)
 });

--- a/resources/js/components/JsonBlock.vue
+++ b/resources/js/components/JsonBlock.vue
@@ -1,0 +1,27 @@
+<template>
+    <template v-if="block.highlight === false">
+        <pre><code ref="plaintextCode" class="language-plaintext" v-text="block.value" /></pre>
+    </template>
+    <highlightjs v-else language="json" :code="block.value" />
+</template>
+
+<script>
+import hljs from 'highlight.js/lib/common'
+import hljsVuePlugin from '@highlightjs/vue-plugin'
+
+export default {
+    components: {
+        highlightjs: hljsVuePlugin.component,
+    },
+
+    props: {
+        block: { type: Object, required: true },
+    },
+
+    mounted() {
+        if (this.block.highlight === false && this.$refs.plaintextCode) {
+            hljs.highlightElement(this.$refs.plaintextCode)
+        }
+    },
+}
+</script>

--- a/resources/js/components/ModalActionResponse.vue
+++ b/resources/js/components/ModalActionResponse.vue
@@ -41,6 +41,7 @@ import HeadingBlock from './HeadingBlock.vue'
 import ListBlock from './ListBlock.vue'
 import BadgeBlock from './BadgeBlock.vue'
 import CodeBlock from './CodeBlock.vue'
+import JsonBlock from './JsonBlock.vue'
 
 export default {
     components: {
@@ -64,6 +65,7 @@ export default {
                 list: ListBlock,
                 badge: BadgeBlock,
                 code: CodeBlock,
+                json: JsonBlock,
             },
         }
     },

--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -3,6 +3,7 @@
 namespace Markwalet\NovaModalResponse\Blocks;
 
 use Illuminate\Support\Stringable;
+use JsonException;
 
 abstract class Block
 {
@@ -47,5 +48,15 @@ abstract class Block
     public static function code(string|Stringable $value): CodeBlock
     {
         return new CodeBlock($value);
+    }
+
+    /**
+     * @param array<mixed> $value
+     *
+     * @throws JsonException
+     */
+    public static function json(array $value): JsonBlock
+    {
+        return new JsonBlock($value);
     }
 }

--- a/src/Blocks/JsonBlock.php
+++ b/src/Blocks/JsonBlock.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Blocks;
+
+use JsonException;
+
+class JsonBlock extends Block
+{
+    private bool $highlight = true;
+
+    private readonly string $encoded;
+
+    /**
+     * @param array<mixed> $value
+     *
+     * @throws JsonException
+     */
+    public function __construct(array $value)
+    {
+        $this->encoded = json_encode($value, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+    }
+
+    public function withoutHighlighting(): self
+    {
+        $this->highlight = false;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => 'json',
+            'value' => $this->encoded,
+            'highlight' => $this->highlight,
+        ];
+    }
+}

--- a/src/ModalResponse.php
+++ b/src/ModalResponse.php
@@ -5,6 +5,7 @@ namespace Markwalet\NovaModalResponse;
 use Closure;
 use Illuminate\Support\Stringable;
 use InvalidArgumentException;
+use JsonException;
 use Laravel\Nova\Actions\ActionResponse;
 use Markwalet\NovaModalResponse\Blocks\Block;
 
@@ -55,6 +56,16 @@ class ModalResponse extends ActionResponse
     public static function code(string|Stringable $value): self
     {
         return self::stack([Block::code($value)]);
+    }
+
+    /**
+     * @param array<mixed> $value
+     *
+     * @throws JsonException
+     */
+    public static function json(array $value): self
+    {
+        return self::stack([Block::json($value)]);
     }
 
     public function title(string $title): self

--- a/tests/Blocks/JsonBlockTest.php
+++ b/tests/Blocks/JsonBlockTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Tests\Blocks;
+
+use JsonException;
+use Markwalet\NovaModalResponse\Blocks\Block;
+use Markwalet\NovaModalResponse\Blocks\JsonBlock;
+use Markwalet\NovaModalResponse\ModalResponse;
+use Markwalet\NovaModalResponse\Tests\TestCase;
+
+class JsonBlockTest extends TestCase
+{
+    public function test_factory_pretty_prints_and_defaults_to_highlight(): void
+    {
+        $block = Block::json(['ok' => true]);
+
+        $this->assertInstanceOf(JsonBlock::class, $block);
+        $this->assertSame(
+            [
+                'type' => 'json',
+                'value' => "{\n    \"ok\": true\n}",
+                'highlight' => true,
+            ],
+            $block->toArray(),
+        );
+    }
+
+    public function test_without_highlighting_disables_highlight(): void
+    {
+        $this->assertSame(
+            [
+                'type' => 'json',
+                'value' => "{\n    \"ok\": true\n}",
+                'highlight' => false,
+            ],
+            Block::json(['ok' => true])->withoutHighlighting()->toArray(),
+        );
+    }
+
+    public function test_invalid_utf8_throws_a_json_exception(): void
+    {
+        $this->expectException(JsonException::class);
+
+        Block::json(['x' => "\xB1\x31"]);
+    }
+
+    public function test_json_sugar_produces_a_single_json_block_stack(): void
+    {
+        $response = ModalResponse::json(['ok' => true]);
+
+        $this->assertSame([
+            'blocks' => [
+                [
+                    'type' => 'json',
+                    'value' => "{\n    \"ok\": true\n}",
+                    'highlight' => true,
+                ],
+            ],
+        ], $response['modal']->payload);
+    }
+}


### PR DESCRIPTION
Closes #24. Stacked on top of #38 (#23 code).

## Summary
- New `JsonBlock` taking `array`; pretty-prints via `JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR` (matches v1 — invalid UTF-8 throws `JsonException`).
- `Block::json($data)` factory; `->withoutHighlighting()` toggles highlight.
- Restored `ModalResponse::json()` one-liner sugar.
- `JsonBlock.vue` highlights via `language="json"` (or plaintext when disabled). Owns highlight.js imports.

## Test plan
- [x] PHP unit tests green (incl. pretty-print, JsonException, withoutHighlighting, sugar); pint + phpstan clean
- [ ] Workbench: json block renders pretty-printed and highlighted

🤖 Generated with [Claude Code](https://claude.com/claude-code)