### PR TITLE
v2 #30: ModalResponse::withoutSyntaxHighlighting() bulk helper

### DIFF
--- a/src/ModalResponse.php
+++ b/src/ModalResponse.php
@@ -83,6 +83,14 @@ class ModalResponse extends ActionResponse
         return $this->setChrome('closeButtonText', $label);
     }
 
+    public function withoutSyntaxHighlighting(): self
+    {
+        $this->withoutHighlight = true;
+        $this->refreshModal();
+
+        return $this;
+    }
+
     private function setChrome(string $key, mixed $value): self
     {
         $this->chrome[$key] = $value;

--- a/src/PayloadBuilder.php
+++ b/src/PayloadBuilder.php
@@ -16,7 +16,15 @@ class PayloadBuilder
         $payload = $chrome;
 
         $payload['blocks'] = array_map(
-            static fn (Block $block): array => $block->toArray(),
+            static function (Block $block) use ($withoutHighlight): array {
+                $serialized = $block->toArray();
+
+                if ($withoutHighlight && in_array($serialized['type'] ?? null, ['code', 'json'], true)) {
+                    $serialized['highlight'] = false;
+                }
+
+                return $serialized;
+            },
             array_values($blocks),
         );
 

--- a/tests/WithoutSyntaxHighlightingTest.php
+++ b/tests/WithoutSyntaxHighlightingTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Tests;
+
+use Markwalet\NovaModalResponse\Blocks\Block;
+use Markwalet\NovaModalResponse\ModalResponse;
+
+class WithoutSyntaxHighlightingTest extends TestCase
+{
+    public function test_called_after_stack_disables_highlight_on_every_code_and_json_block(): void
+    {
+        $response = ModalResponse::stack([
+            Block::code('echo 1;'),
+            Block::json(['ok' => true]),
+        ])->withoutSyntaxHighlighting();
+
+        $this->assertSame([
+            'blocks' => [
+                ['type' => 'code', 'value' => 'echo 1;', 'highlight' => false],
+                ['type' => 'json', 'value' => "{\n    \"ok\": true\n}", 'highlight' => false],
+            ],
+        ], $response['modal']->payload);
+    }
+
+    public function test_does_not_override_per_block_highlight_already_disabled(): void
+    {
+        $response = ModalResponse::stack([
+            Block::code('x')->withoutHighlighting(),
+            Block::json(['ok' => true])->withoutHighlighting(),
+        ])->withoutSyntaxHighlighting();
+
+        $this->assertSame([
+            ['type' => 'code', 'value' => 'x', 'highlight' => false],
+            ['type' => 'json', 'value' => "{\n    \"ok\": true\n}", 'highlight' => false],
+        ], $response['modal']->payload['blocks']);
+    }
+
+    public function test_non_code_or_json_blocks_are_untouched(): void
+    {
+        $response = ModalResponse::stack([
+            Block::text('hi'),
+            Block::badge('Draft'),
+            Block::divider(),
+            Block::heading('Title'),
+            Block::html('<b>x</b>'),
+            Block::list(['a']),
+        ])->withoutSyntaxHighlighting();
+
+        $this->assertSame([
+            'blocks' => [
+                ['type' => 'text', 'value' => 'hi'],
+                ['type' => 'badge', 'value' => 'Draft', 'variant' => 'default'],
+                ['type' => 'divider'],
+                ['type' => 'heading', 'value' => 'Title', 'size' => 'medium'],
+                ['type' => 'html', 'value' => '<b>x</b>'],
+                ['type' => 'list', 'value' => ['a'], 'ordered' => false],
+            ],
+        ], $response['modal']->payload);
+    }
+
+    public function test_mixed_stack_only_mutates_code_and_json(): void
+    {
+        $response = ModalResponse::stack([
+            Block::text('intro'),
+            Block::code('echo 1;'),
+            Block::badge('x'),
+            Block::json(['ok' => true]),
+        ])->withoutSyntaxHighlighting();
+
+        $this->assertSame([
+            ['type' => 'text', 'value' => 'intro'],
+            ['type' => 'code', 'value' => 'echo 1;', 'highlight' => false],
+            ['type' => 'badge', 'value' => 'x', 'variant' => 'default'],
+            ['type' => 'json', 'value' => "{\n    \"ok\": true\n}", 'highlight' => false],
+        ], $response['modal']->payload['blocks']);
+    }
+
+    public function test_wire_carries_no_top_level_highlight_field(): void
+    {
+        $response = ModalResponse::stack([Block::code('echo 1;')])->withoutSyntaxHighlighting();
+
+        $this->assertArrayNotHasKey('highlight', $response['modal']->payload);
+    }
+
+    public function test_legacy_modal_response_code_with_without_syntax_highlighting_produces_expected_wire(): void
+    {
+        $response = ModalResponse::code('echo 1;')->withoutSyntaxHighlighting();
+
+        $this->assertSame([
+            'blocks' => [
+                ['type' => 'code', 'value' => 'echo 1;', 'highlight' => false],
+            ],
+        ], $response['modal']->payload);
+    }
+}


### PR DESCRIPTION
Closes #30.

## Summary
- New instance method `ModalResponse::withoutSyntaxHighlighting(): self` — chainable, sets a flag and re-serializes.
- `PayloadBuilder` walks each block at serialize time; when the flag is set, any `code` or `json` block's `highlight` is forced to `false`. All other block types are untouched.
- The wire format carries no top-level `highlight` field — only per-block.
- Legacy BC: `ModalResponse::code(\$s)->withoutSyntaxHighlighting()` now produces `[code, value, highlight=false]` as before.

## Test plan
- [x] After `stack()`: forces `highlight: false` on every code/json block
- [x] Per-block `Block::code()->withoutHighlighting()` still works
- [x] Mixed-block stack only mutates code/json
- [x] Non-code/json blocks (text/html/heading/list/badge/divider) untouched
- [x] No top-level `highlight` key on the wire
- [x] `ModalResponse::code(\$s)->withoutSyntaxHighlighting()` BC path
- [x] `vendor/bin/phpunit`, `vendor/bin/pint`, `vendor/bin/phpstan` all green
- [ ] Workbench: trigger an action with the bulk helper and confirm code/json render unhighlighted

🤖 Generated with [Claude Code](https://claude.com/claude-code)