### PR TITLE
Remove raw Action::modal pattern from docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Added a Laravel Boost AI guideline so agents can use the package correctly ([#43](https://github.com/markwalet/nova-modal-response/issues/43))
 
+### Changed
+- Removed the raw `Action::modal('modal-response', [...])` pattern from the docs in favour of the `ModalResponse` helper ([#41](https://github.com/markwalet/nova-modal-response/issues/41))
+
 ## [v1.1.0 (2026-03-30)](https://github.com/markwalet/nova-modal-response/compare/v1.0.3...v1.1.0)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,15 +26,9 @@ use Markwalet\NovaModalResponse\ModalResponse;
 
 ModalResponse::text('This is way better than that small notification in the bottom right!')
     ->title('Result in a modal');
-
-// Modals can also be manually created in Nova
-use Laravel\Nova\Actions\Action;
-
-return Action::modal('modal-response', [
-    'title' => 'Result in a model',
-    'body' => 'This is way better than that small notification in the bottom right!',
-]);
 ```
+
+> **Note:** Always build responses through the `ModalResponse` helper. Hand-rolling the raw payload with `Action::modal('modal-response', [...])` is not a supported part of this package's API and may break without notice.
 
 When you want to render raw html, you can use the `html` parameter instead:
 


### PR DESCRIPTION
Closes #41.

The README documented hand-rolling the modal payload with `Action::modal('modal-response', ['body' => ...])` as a usage example. That bypasses the `ModalResponse` helper, which is the supported API, and is exactly the shape that breaks on the v2 upgrade.

## Changes
- Removed the raw `Action::modal('modal-response', [...])` example from the README quick-start.
- Added a short note steering callers to the `ModalResponse` helper and flagging the raw payload as unsupported.
- Added a CHANGELOG entry under `Unreleased`.

## Notes
This is the docs/deprecation half. The sibling issue #42 (Vue dispatcher legacy-key warning) is genuinely v2-only — it warns on `body`/`code`/`html`/`highlight`, which are still the live API in v1 — so it is intentionally left out of this PR.

## Acceptance
- `git grep "Action::modal" README.md` returns no usage examples (only the prose note describing it as unsupported).
- README quick-start uses the `ModalResponse` helper.
- CHANGELOG names the raw-payload pattern removal and links #41.