### PR TITLE
v2 #42: warn in Vue dispatcher on legacy payload keys

### DIFF
--- a/resources/js/components/ModalActionResponse.vue
+++ b/resources/js/components/ModalActionResponse.vue
@@ -43,6 +43,15 @@ import BadgeBlock from './BadgeBlock.vue'
 import CodeBlock from './CodeBlock.vue'
 import JsonBlock from './JsonBlock.vue'
 
+// v1 wire keys that v2 dropped in favour of `data.blocks`. A payload still
+// carrying any of these renders an empty modal body, so we warn instead of
+// silently rendering nothing. See ADR-0001 and UPGRADE.md.
+const LEGACY_KEYS = ['body', 'code', 'html', 'highlight']
+
+// Tracks `data` objects already warned about so re-renders don't spam the
+// console. A fresh modal open ships a fresh `data` object, so it still warns.
+const warnedPayloads = new WeakSet()
+
 export default {
     components: {
         Button,
@@ -70,9 +79,35 @@ export default {
         }
     },
 
+    mounted() {
+        this.warnOnLegacyPayload()
+    },
+
     methods: {
         handleClose() {
             this.$emit('close')
+        },
+
+        warnOnLegacyPayload() {
+            if (warnedPayloads.has(this.data)) {
+                return
+            }
+
+            const hasLegacyKeys = LEGACY_KEYS.some(
+                key => Object.prototype.hasOwnProperty.call(this.data, key)
+            )
+
+            if (!hasLegacyKeys) {
+                return
+            }
+
+            warnedPayloads.add(this.data)
+
+            console.warn(
+                '[nova-modal-response] Legacy payload keys detected on data (one of: body, code, html, highlight).\n' +
+                'These were removed in v2.0. Use ModalResponse::stack(...) or the static sugar\n' +
+                '(ModalResponse::text/code/html/json) on the PHP side. See UPGRADE.md.'
+            )
         },
     },
 }


### PR DESCRIPTION
Closes #42.

## What

`ModalActionResponse.vue` now logs a one-shot `console.warn` when a modal opens with a `data` payload still carrying any v1 wire key (`body`, `code`, `html`, or top-level `highlight`). In v2 such a payload renders a silently empty modal body; the warn turns that into an obvious failure pointing at the fix.

## How

- A module-level `LEGACY_KEYS` list and a `warnOnLegacyPayload()` method, called from `mounted()`. Nova mounts the modal component fresh per open, so this fires once per open.
- A module-level `WeakSet` of already-warned `data` objects dedupes re-renders within a single open. A fresh modal open ships a fresh `data` object, so opening the same modal twice still produces two warns.
- **Does not** render the legacy shape — the warn replaces the missing render (ADR-0001 rejected a Vue-side shim).
- Plain `console.warn`, intentionally **not** stripped in production — the silent-empty-modal failure mode is exactly when it earns its keep (laravel-mix/Terser keeps `console.warn`).

## Docs

The warn is already documented in `UPGRADE.md` (the component-override and raw-payload sections).

## Notes

- Branched off `v2` (stacked on the block-dispatch work), not `main`.
- No `dist/` rebuild — consistent with the other v2 feature PRs; the bundle rebuild is owned by the release issue (#31).
- No JS tests added (the repo has no JS test harness; suite is PHP-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)