### PR TITLE
v2: inline group block (Inlineable marker, text + badge atoms)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,3 +13,7 @@ Canonical label vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `re
 ### Domain docs
 
 Single-context layout: one `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+
+### Preview env
+
+How to spin up a local review environment (target branch, setup steps, serve command) for the `implement-issues` skill. See `docs/agents/preview-env.md`.

--- a/docs/agents/preview-env.md
+++ b/docs/agents/preview-env.md
@@ -1,0 +1,38 @@
+# Preview env
+
+How the `implement-issues` skill spins up a local environment so a human can
+review an implemented issue before the PR is opened. Edit this file to match the
+project; the skill reads it at runtime.
+
+## Target branch
+
+`v2` — feature branches are cut from it and PRs target it. (Switch to `main` once
+v2 is released.)
+
+## Setup steps (before serving)
+
+Run in order from the repo root. None required today beyond the build that
+`serve` already does. Add migrate/seed/env/fixture steps here as the workbench
+grows, e.g.:
+
+```sh
+# (none yet)
+# cp .env.example .env        # if a workbench env is introduced
+# php artisan migrate --seed  # if the workbench gains a DB
+```
+
+## Serve
+
+```sh
+composer run serve -- --port <PORT>
+```
+
+`composer run serve` runs `workbench:build` then `testbench serve`. The skill
+picks a random free high port for `<PORT>` and prints the `http://127.0.0.1:<PORT>`
+URL.
+
+## What to click
+
+The workbench registers demo actions on the **`User`** Nova resource (e.g.
+`ViewJsonSnippetModalAction`). Open a user, trigger the action(s) the issue
+touches, and confirm the modal renders the new block/behaviour.

--- a/resources/js/asset.js
+++ b/resources/js/asset.js
@@ -7,6 +7,7 @@ import ListBlock from './components/ListBlock'
 import BadgeBlock from './components/BadgeBlock'
 import CodeBlock from './components/CodeBlock'
 import JsonBlock from './components/JsonBlock'
+import InlineBlock from './components/InlineBlock'
 
 Nova.booting(app => {
     app.component('modal-response', ModalActionResponse)
@@ -18,4 +19,5 @@ Nova.booting(app => {
     app.component('modal-response-badge-block', BadgeBlock)
     app.component('modal-response-code-block', CodeBlock)
     app.component('modal-response-json-block', JsonBlock)
+    app.component('modal-response-inline-block', InlineBlock)
 });

--- a/resources/js/components/InlineBlock.vue
+++ b/resources/js/components/InlineBlock.vue
@@ -1,0 +1,31 @@
+<template>
+    <div class="py-3 px-8">
+        <div
+            class="flex flex-wrap items-center gap-x-2 gap-y-1"
+            :class="block.spread ? 'justify-between' : 'justify-start'"
+        >
+            <component
+                v-for="(atom, index) in (block.value ?? [])"
+                :is="blockComponents[atom.type]"
+                :key="index"
+                :block="atom"
+            />
+        </div>
+    </div>
+</template>
+
+<script>
+import { blockComponents } from './blockComponents.js'
+
+export default {
+    props: {
+        block: { type: Object, required: true },
+    },
+
+    data() {
+        return {
+            blockComponents,
+        }
+    },
+}
+</script>

--- a/resources/js/components/ModalActionResponse.vue
+++ b/resources/js/components/ModalActionResponse.vue
@@ -34,14 +34,7 @@
 
 <script>
 import { Button } from 'laravel-nova-ui'
-import TextBlock from './TextBlock.vue'
-import DividerBlock from './DividerBlock.vue'
-import HtmlBlock from './HtmlBlock.vue'
-import HeadingBlock from './HeadingBlock.vue'
-import ListBlock from './ListBlock.vue'
-import BadgeBlock from './BadgeBlock.vue'
-import CodeBlock from './CodeBlock.vue'
-import JsonBlock from './JsonBlock.vue'
+import { blockComponents } from './blockComponents.js'
 
 // v1 wire keys that v2 dropped in favour of `data.blocks`. A payload still
 // carrying any of these renders an empty modal body, so we warn instead of
@@ -66,16 +59,7 @@ export default {
 
     data() {
         return {
-            blockComponents: {
-                text: TextBlock,
-                divider: DividerBlock,
-                html: HtmlBlock,
-                heading: HeadingBlock,
-                list: ListBlock,
-                badge: BadgeBlock,
-                code: CodeBlock,
-                json: JsonBlock,
-            },
+            blockComponents,
         }
     },
 

--- a/resources/js/components/blockComponents.js
+++ b/resources/js/components/blockComponents.js
@@ -1,0 +1,24 @@
+import TextBlock from './TextBlock.vue'
+import DividerBlock from './DividerBlock.vue'
+import HtmlBlock from './HtmlBlock.vue'
+import HeadingBlock from './HeadingBlock.vue'
+import ListBlock from './ListBlock.vue'
+import BadgeBlock from './BadgeBlock.vue'
+import CodeBlock from './CodeBlock.vue'
+import JsonBlock from './JsonBlock.vue'
+import InlineBlock from './InlineBlock.vue'
+
+// The single source of truth mapping a block `type` to the component that
+// renders it. Both the stack (ModalActionResponse.vue) and the inline group
+// (InlineBlock.vue) dispatch through this one map — one map, two sites.
+export const blockComponents = {
+    text: TextBlock,
+    divider: DividerBlock,
+    html: HtmlBlock,
+    heading: HeadingBlock,
+    list: ListBlock,
+    badge: BadgeBlock,
+    code: CodeBlock,
+    json: JsonBlock,
+    inline: InlineBlock,
+}

--- a/src/Blocks/BadgeBlock.php
+++ b/src/Blocks/BadgeBlock.php
@@ -4,7 +4,7 @@ namespace Markwalet\NovaModalResponse\Blocks;
 
 use Illuminate\Support\Stringable;
 
-class BadgeBlock extends Block
+class BadgeBlock extends Block implements Inlineable
 {
     private string $variant = 'default';
 

--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -51,6 +51,14 @@ abstract class Block
     }
 
     /**
+     * @param array<int, Block> $atoms
+     */
+    public static function inline(array $atoms): InlineBlock
+    {
+        return new InlineBlock($atoms);
+    }
+
+    /**
      * @param array<mixed> $value
      *
      * @throws JsonException

--- a/src/Blocks/InlineBlock.php
+++ b/src/Blocks/InlineBlock.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Blocks;
+
+use InvalidArgumentException;
+
+class InlineBlock extends Block
+{
+    private bool $spread = false;
+
+    /** @var list<Block&Inlineable> */
+    private readonly array $atoms;
+
+    /**
+     * @param array<int, Block> $atoms
+     */
+    public function __construct(array $atoms)
+    {
+        $validated = [];
+
+        foreach ($atoms as $atom) {
+            if (! $atom instanceof Inlineable) {
+                throw new InvalidArgumentException('Inline group may only contain Inlineable atoms.');
+            }
+
+            $validated[] = $atom;
+        }
+
+        $this->atoms = $validated;
+    }
+
+    public function spread(): self
+    {
+        $this->spread = true;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => 'inline',
+            'spread' => $this->spread,
+            'value' => array_map(static fn (Block $atom): array => $atom->toArray(), $this->atoms),
+        ];
+    }
+}

--- a/src/Blocks/Inlineable.php
+++ b/src/Blocks/Inlineable.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Blocks;
+
+/**
+ * Marks a block as an inline atom: a block that may sit inside an inline group
+ * and render on a single horizontal row. Implementing this interface is a
+ * promise about layout only; it does not change a block's serialized output.
+ */
+interface Inlineable {}

--- a/src/Blocks/TextBlock.php
+++ b/src/Blocks/TextBlock.php
@@ -4,7 +4,7 @@ namespace Markwalet\NovaModalResponse\Blocks;
 
 use Illuminate\Support\Stringable;
 
-class TextBlock extends Block
+class TextBlock extends Block implements Inlineable
 {
     public function __construct(private readonly string|Stringable $value) {}
 

--- a/tests/Blocks/BlockFactoryTest.php
+++ b/tests/Blocks/BlockFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Markwalet\NovaModalResponse\Tests\Blocks;
 
 use Markwalet\NovaModalResponse\Blocks\Block;
+use Markwalet\NovaModalResponse\Blocks\InlineBlock;
 use Markwalet\NovaModalResponse\Blocks\TextBlock;
 use Markwalet\NovaModalResponse\Tests\TestCase;
 
@@ -14,5 +15,12 @@ class BlockFactoryTest extends TestCase
 
         $this->assertInstanceOf(TextBlock::class, $block);
         $this->assertSame(['type' => 'text', 'value' => 'hello'], $block->toArray());
+    }
+
+    public function test_inline_factory_returns_an_inline_block(): void
+    {
+        $block = Block::inline([Block::text('hello')]);
+
+        $this->assertInstanceOf(InlineBlock::class, $block);
     }
 }

--- a/tests/Blocks/InlineBlockTest.php
+++ b/tests/Blocks/InlineBlockTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Tests\Blocks;
+
+use InvalidArgumentException;
+use Markwalet\NovaModalResponse\Blocks\Block;
+use Markwalet\NovaModalResponse\Blocks\InlineBlock;
+use Markwalet\NovaModalResponse\Tests\TestCase;
+
+class InlineBlockTest extends TestCase
+{
+    public function test_factory_returns_an_inline_block_packed_by_default(): void
+    {
+        $block = Block::inline([Block::text('Status'), Block::badge('Active')->success()]);
+
+        $this->assertInstanceOf(InlineBlock::class, $block);
+        $this->assertSame([
+            'type' => 'inline',
+            'spread' => false,
+            'value' => [
+                ['type' => 'text', 'value' => 'Status'],
+                ['type' => 'badge', 'value' => 'Active', 'variant' => 'success'],
+            ],
+        ], $block->toArray());
+    }
+
+    public function test_atoms_keep_their_order(): void
+    {
+        $block = Block::inline([Block::badge('first'), Block::text('second')]);
+
+        $this->assertSame(
+            ['first', 'second'],
+            array_column($block->toArray()['value'], 'value'),
+        );
+    }
+
+    public function test_spread_flips_the_layout_knob(): void
+    {
+        $block = Block::inline([Block::text('key'), Block::badge('value')])->spread();
+
+        $this->assertSame([
+            'type' => 'inline',
+            'spread' => true,
+            'value' => [
+                ['type' => 'text', 'value' => 'key'],
+                ['type' => 'badge', 'value' => 'value', 'variant' => 'default'],
+            ],
+        ], $block->toArray());
+    }
+
+    public function test_atoms_serialize_through_their_own_to_array(): void
+    {
+        $block = Block::inline([Block::text('Plain')]);
+
+        $this->assertSame(
+            [['type' => 'text', 'value' => 'Plain']],
+            $block->toArray()['value'],
+        );
+    }
+
+    public function test_an_empty_group_serializes_to_an_empty_value_list(): void
+    {
+        $this->assertSame([
+            'type' => 'inline',
+            'spread' => false,
+            'value' => [],
+        ], Block::inline([])->toArray());
+    }
+
+    public function test_a_non_inlineable_block_is_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Block::inline([Block::text('ok'), Block::code('not allowed')]);
+    }
+
+    public function test_a_divider_is_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Block::inline([Block::divider()]);
+    }
+
+    public function test_a_list_is_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Block::inline([Block::list(['a', 'b'])]);
+    }
+
+    public function test_inline_groups_cannot_nest(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Block::inline([Block::inline([Block::text('inner')])]);
+    }
+}

--- a/tests/ModalResponseTest.php
+++ b/tests/ModalResponseTest.php
@@ -55,6 +55,26 @@ class ModalResponseTest extends TestCase
         $this->assertSame(['blocks' => []], $response['modal']->payload);
     }
 
+    public function test_an_inline_group_serialises_inside_the_stack(): void
+    {
+        $response = ModalResponse::stack([
+            Block::inline([Block::text('Status'), Block::badge('Active')->success()])->spread(),
+        ]);
+
+        $this->assertSame([
+            'blocks' => [
+                [
+                    'type' => 'inline',
+                    'spread' => true,
+                    'value' => [
+                        ['type' => 'text', 'value' => 'Status'],
+                        ['type' => 'badge', 'value' => 'Active', 'variant' => 'success'],
+                    ],
+                ],
+            ],
+        ], $response['modal']->payload);
+    }
+
     public function test_stack_with_an_array_of_blocks_writes_the_blocks_wire_payload(): void
     {
         $response = ModalResponse::stack([Block::text('hi')]);

--- a/workbench/app/Nova/Actions/ViewTextStackAction.php
+++ b/workbench/app/Nova/Actions/ViewTextStackAction.php
@@ -40,6 +40,17 @@ class ViewTextStackAction extends Action
             Block::badge('Deprecated')->warning(),
             Block::badge('Archived')->danger(),
             Block::divider(),
+            Block::heading('Inline group — packed (default)')->small(),
+            Block::inline([
+                Block::text('Status:'),
+                Block::badge('Published')->success(),
+            ]),
+            Block::heading('Inline group — spread (key/value row)')->small(),
+            Block::inline([
+                Block::text('Deployment'),
+                Block::badge('Live')->success(),
+            ])->spread(),
+            Block::divider(),
             Block::heading('Code — autodetect')->small(),
             Block::code("<?php\n\nfunction greet(string \$name): string {\n    return \"Hello, {\$name}!\";\n}"),
             Block::heading('Code — explicit language (sql)')->small(),


### PR DESCRIPTION
Introduces horizontal layout into the modal body via a single `inline` group block, end-to-end.

- `Inlineable` marker interface; `TextBlock` and `BadgeBlock` implement it (no wire-format change to their `toArray()`).
- `InlineBlock` + `Block::inline([...])` factory. Not `Inlineable` itself, so groups can't nest. Constructor throws `InvalidArgumentException` for non-`Inlineable` items, mirroring the `stack()` guard.
- `->spread()` knob: default packed-left with a consistent gap; `spread()` switches to space-between for key/value rows.
- Wire format: `{ "type": "inline", "spread": bool, "value": [<atom>, …] }`.
- Vue: extracted the `type → component` map into a shared `blockComponents.js` (one map, two dispatch sites); new `InlineBlock.vue` renders atoms in a wrapping, vertically-centred flex row.
- Workbench: inline-group demo added to the "View text stack" action on the User resource.

Tests: 51 passed (added `InlineBlockTest` covering wire type/spread/value and the four guard cases). Larastan + Pint clean.

Note: the issue referenced ADR-0002 and CONTEXT.md glossary terms that don't exist yet — implemented following ADR-0001's additive pattern without inventing them; a follow-up to write ADR-0002 + glossary entries is worthwhile.

Closes #47