### PR TITLE
Coerce bare strings to text blocks in inline() and stack()

### DIFF
--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -3,7 +3,9 @@
 namespace Markwalet\NovaModalResponse\Blocks;
 
 use Illuminate\Support\Stringable;
+use InvalidArgumentException;
 use JsonException;
+use Stringable as StringableInterface;
 
 abstract class Block
 {
@@ -11,6 +13,22 @@ abstract class Block
      * @return array<string, mixed>
      */
     abstract public function toArray(): array;
+
+    /**
+     * Coerce a value into a Block: instances pass through, strings become text blocks.
+     */
+    public static function normalize(mixed $block): Block
+    {
+        if ($block instanceof Block) {
+            return $block;
+        }
+
+        if (is_string($block) || $block instanceof StringableInterface) {
+            return self::text((string) $block);
+        }
+
+        throw new InvalidArgumentException('Blocks must be Block instances or strings.');
+    }
 
     public static function text(string|Stringable $value): TextBlock
     {
@@ -33,7 +51,7 @@ abstract class Block
     }
 
     /**
-     * @param array<int, string|\Stringable> $items
+     * @param array<int, string|StringableInterface> $items
      */
     public static function list(array $items): ListBlock
     {
@@ -61,7 +79,7 @@ abstract class Block
     }
 
     /**
-     * @param array<int, Block> $atoms
+     * @param array<int, Block|string|StringableInterface> $atoms
      */
     public static function inline(array $atoms): InlineBlock
     {

--- a/src/Blocks/InlineBlock.php
+++ b/src/Blocks/InlineBlock.php
@@ -3,6 +3,7 @@
 namespace Markwalet\NovaModalResponse\Blocks;
 
 use InvalidArgumentException;
+use Stringable;
 
 class InlineBlock extends Block
 {
@@ -12,13 +13,15 @@ class InlineBlock extends Block
     private readonly array $atoms;
 
     /**
-     * @param array<int, Block> $atoms
+     * @param array<int, Block|string|Stringable> $atoms
      */
     public function __construct(array $atoms)
     {
         $validated = [];
 
         foreach ($atoms as $atom) {
+            $atom = Block::normalize($atom);
+
             if (! $atom instanceof Inlineable) {
                 throw new InvalidArgumentException('Inline group may only contain Inlineable atoms.');
             }

--- a/src/ModalResponse.php
+++ b/src/ModalResponse.php
@@ -20,7 +20,7 @@ class ModalResponse extends ActionResponse
     private bool $withoutHighlight = false;
 
     /**
-     * @param array<int, Block>|Closure $blocks
+     * @param array<int, Block|string|Stringable>|Closure $blocks
      */
     public static function stack(array|Closure $blocks): self
     {
@@ -31,13 +31,7 @@ class ModalResponse extends ActionResponse
             throw new InvalidArgumentException('Stack closure must return an array of Block instances.');
         }
 
-        foreach ($resolved as $block) {
-            if (! $block instanceof Block) {
-                throw new InvalidArgumentException('Stack must contain only Block instances.');
-            }
-        }
-
-        $response->blocks = array_values($resolved);
+        $response->blocks = array_values(array_map(Block::normalize(...), $resolved));
         $response->refreshModal();
 
         return $response;

--- a/tests/Blocks/BlockFactoryTest.php
+++ b/tests/Blocks/BlockFactoryTest.php
@@ -2,6 +2,8 @@
 
 namespace Markwalet\NovaModalResponse\Tests\Blocks;
 
+use Illuminate\Support\Stringable;
+use InvalidArgumentException;
 use Markwalet\NovaModalResponse\Blocks\Block;
 use Markwalet\NovaModalResponse\Blocks\InlineBlock;
 use Markwalet\NovaModalResponse\Blocks\LinkBlock;
@@ -30,5 +32,44 @@ class BlockFactoryTest extends TestCase
         $block = Block::link('Docs', 'https://example.test');
 
         $this->assertInstanceOf(LinkBlock::class, $block);
+    }
+
+    public function test_normalize_passes_block_instances_through_unchanged(): void
+    {
+        $block = Block::badge('New');
+
+        $this->assertSame($block, Block::normalize($block));
+    }
+
+    public function test_normalize_coerces_a_string_into_a_text_block(): void
+    {
+        $block = Block::normalize('Hello');
+
+        $this->assertInstanceOf(TextBlock::class, $block);
+        $this->assertSame(['type' => 'text', 'value' => 'Hello'], $block->toArray());
+    }
+
+    public function test_normalize_coerces_a_stringable_into_a_text_block(): void
+    {
+        $block = Block::normalize(new Stringable('Hello'));
+
+        $this->assertInstanceOf(TextBlock::class, $block);
+        $this->assertSame(['type' => 'text', 'value' => 'Hello'], $block->toArray());
+    }
+
+    public function test_normalize_serializes_identically_to_an_explicit_text_block(): void
+    {
+        $this->assertSame(
+            Block::text('Hello')->toArray(),
+            Block::normalize('Hello')->toArray(),
+        );
+    }
+
+    public function test_normalize_rejects_a_non_block_non_string_value(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Blocks must be Block instances or strings.');
+
+        Block::normalize(42);
     }
 }

--- a/tests/Blocks/InlineBlockTest.php
+++ b/tests/Blocks/InlineBlockTest.php
@@ -67,9 +67,32 @@ class InlineBlockTest extends TestCase
         ], Block::inline([])->toArray());
     }
 
+    public function test_bare_strings_are_coerced_to_text_atoms(): void
+    {
+        $block = Block::inline(['Hello', Block::badge('New')]);
+
+        $this->assertSame([
+            'type' => 'inline',
+            'spread' => false,
+            'value' => [
+                ['type' => 'text', 'value' => 'Hello'],
+                ['type' => 'badge', 'value' => 'New', 'variant' => 'default'],
+            ],
+        ], $block->toArray());
+    }
+
+    public function test_a_non_block_non_string_atom_is_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Blocks must be Block instances or strings.');
+
+        Block::inline([42]);
+    }
+
     public function test_a_non_inlineable_block_is_rejected(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Inline group may only contain Inlineable atoms.');
 
         Block::inline([Block::text('ok'), Block::code('not allowed')]);
     }

--- a/tests/ModalResponseTest.php
+++ b/tests/ModalResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace Markwalet\NovaModalResponse\Tests;
 
+use InvalidArgumentException;
 use Laravel\Nova\Actions\Responses\Modal;
 use Markwalet\NovaModalResponse\Blocks\Block;
 use Markwalet\NovaModalResponse\ModalResponse;
@@ -73,6 +74,26 @@ class ModalResponseTest extends TestCase
                 ],
             ],
         ], $response['modal']->payload);
+    }
+
+    public function test_stack_coerces_bare_strings_into_text_blocks(): void
+    {
+        $response = ModalResponse::stack(['Hello', Block::badge('New')]);
+
+        $this->assertSame([
+            'blocks' => [
+                ['type' => 'text', 'value' => 'Hello'],
+                ['type' => 'badge', 'value' => 'New', 'variant' => 'default'],
+            ],
+        ], $response['modal']->payload);
+    }
+
+    public function test_stack_rejects_a_non_block_non_string_value(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Blocks must be Block instances or strings.');
+
+        ModalResponse::stack([42]);
     }
 
     public function test_stack_with_an_array_of_blocks_writes_the_blocks_wire_payload(): void


### PR DESCRIPTION
A shared `Block::normalize()` rule — "a string is shorthand for a text block" — applied at both `Block::inline()` and `ModalResponse::stack()`.

## Changes
- `Block::normalize()` passes `Block` instances through, coerces `string|Stringable` into a `TextBlock`, and throws `InvalidArgumentException('Blocks must be Block instances or strings.')` otherwise.
- `InlineBlock` normalizes each atom first, then checks `Inlineable` as before — a non-inlineable real block still throws the existing "may only contain Inlineable atoms" message.
- `ModalResponse::stack()` maps `normalize()` over its blocks, replacing the old "Stack must contain only Block instances." throw.

Coercion is server-side only; a coerced string serializes identically to an explicit `Block::text()`, so no frontend change is needed.

## Tests
Coercion + both error paths covered for `normalize()`, `inline()`, and `stack()`.

Closes #56