### PR TITLE
Add markdown block

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,7 +17,7 @@ The ordered sequence of blocks that makes up a modal's body content. Set via `Mo
 _Avoid_: body, content list, items
 
 **Block**:
-A single, typed unit of modal body content. Blocks render top-to-bottom in the given order. Built-in types: `text`, `heading`, `code`, `json`, `html`, `badge`, `divider`, `list`, `link`, `icon` (plus the **view block**, an authoring-only sugar that serializes as `html`).
+A single, typed unit of modal body content. Blocks render top-to-bottom in the given order. Built-in types: `text`, `heading`, `code`, `json`, `html`, `badge`, `divider`, `list`, `link`, `icon` (plus the authoring-only **view block** and **markdown block**, which both serialize as `html`).
 _Avoid_: element, node, section
 
 **View block**:
@@ -31,6 +31,10 @@ _Avoid_: row, inline block content, flex container
 **Atom**:
 A block permitted inside an **inline group**: `text`, `badge`, `icon`, `link`. Marked in PHP by the `Inlineable` interface — a promise about layout only (it may sit on a horizontal row); it does not change the block's serialized output. Blocks that are not atoms (e.g. `heading`, `code`, `divider`) are rejected from an inline group, as is a nested inline group.
 _Avoid_: inline element, item, child block
+
+**Markdown block**:
+An authoring-time, block-level block built via `Block::markdown(content:|file:)`. It compiles Markdown to HTML at serialize time (Laravel's `Str::markdown()`, GitHub-flavored) and emits `type: html` on the wire — it has **no wire type and no Vue component of its own**, reusing `HtmlBlock.vue` to keep the single render path (ADR-0001) intact. Exactly one source: passing both `content` and `file`, or neither, throws; a missing/unreadable file throws at serialize. Block-level only (it produces `<h1>`/`<p>`-level HTML), so it is **not** an atom. Same trusted-input model as the `html` block — no sanitization.
+_Avoid_: md block, markdown wire type, markdown component
 
 **Heading block**:
 A content-level heading inside the modal body. Carries a **visual size** (`small`, `medium`, `large`) — not a semantic HTML level. Distinct from the modal title.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,7 +33,7 @@ A block permitted inside an **inline group**: `text`, `badge`, `icon`, `link`. M
 _Avoid_: inline element, item, child block
 
 **Markdown block**:
-An authoring-time, block-level block built via `Block::markdown(content:|file:)`. It compiles Markdown to HTML at serialize time (Laravel's `Str::markdown()`, GitHub-flavored) and emits `type: html` on the wire — it has **no wire type and no Vue component of its own**, reusing `HtmlBlock.vue` to keep the single render path (ADR-0001) intact. Exactly one source: passing both `content` and `file`, or neither, throws; a missing/unreadable file throws at serialize. Block-level only (it produces `<h1>`/`<p>`-level HTML), so it is **not** an atom. Same trusted-input model as the `html` block — no sanitization.
+An authoring-time, block-level block built via `Block::markdown($content)`, with `ModalResponse::markdown($content)` sugar to render markdown as the whole modal body. It compiles Markdown to HTML at serialize time (Laravel's `Str::markdown()`, GitHub-flavored) and emits `type: html` on the wire — it has **no wire type and no Vue component of its own**, reusing `HtmlBlock.vue` to keep the single render path (ADR-0001) intact. `$content` is inline markdown by default; chaining `->file()` marks it as a filesystem path instead, which is read and compiled at serialize (a missing/unreadable file then throws). File-based markdown stays available via `ModalResponse::stack([Block::markdown($path)->file()])`. Block-level only (it produces `<h1>`/`<p>`-level HTML), so it is **not** an atom. Same trusted-input model as the `html` block — no sanitization.
 _Avoid_: md block, markdown wire type, markdown component
 
 **Heading block**:

--- a/docs/adr/0002-markdown-block-compiles-to-html-wire-type.md
+++ b/docs/adr/0002-markdown-block-compiles-to-html-wire-type.md
@@ -1,0 +1,53 @@
+# Markdown block compiles to the existing `html` wire type
+
+## Context
+
+ADR-0001 established a uniform render pipeline: each block type maps one-to-one
+to a Vue component through an explicit `{ type → component }` map, and adding a
+block is "a new PHP factory + a new Vue component + an entry in the component
+map". The codebase reinforces this with a `{Type}Block.php ↔ {Type}Block.vue ↔
+type` naming convention.
+
+A Markdown block breaks the symmetry of that convention. Markdown is a *source
+format*, not a *render target*: GitHub-flavored Markdown compiles to ordinary
+block-level HTML (`<h1>`, `<p>`, `<ul>`, tables, …). There are two ways to ship
+it:
+
+1. Introduce a `markdown` wire type with its own `MarkdownBlock.vue` that renders
+   Markdown client-side (a new JS dependency, e.g. a browser Markdown parser).
+2. Compile to HTML in PHP at serialize time and emit `type: html` — no new wire
+   type, no Vue component, no JS dependency.
+
+## Decision
+
+`MarkdownBlock` compiles its content with Laravel's `Str::markdown()`
+(bundled `league/commonmark`, GitHub-flavored, safe-by-default config) at
+`toArray()` time and emits `{ type: 'html', value: '<compiled html>' }`. It has
+**no wire type and no Vue component of its own** — it reuses `HtmlBlock.vue`.
+
+This is a deliberate, hard-to-reverse break of the
+`{Type}Block ↔ {Type}Block.vue ↔ type` convention: `MarkdownBlock.php` exists
+with no matching `MarkdownBlock.vue` and no `markdown` entry in the component
+map. The rationale is recorded here so a future reader does not "fix" the
+apparent inconsistency by adding a client-side renderer.
+
+## Considered alternatives
+
+- **A distinct `markdown` wire type with client-side rendering.** Rejected: it
+  adds a second render path for content that is already HTML, pulls in a JS
+  Markdown dependency, and would mean the wire carries un-compiled Markdown
+  (raw source) to the browser — a larger, less-safe payload than the compiled,
+  escaped HTML. It buys nothing over compiling in PHP.
+- **Silent precedence when both `content` and `file` are passed.** Rejected on
+  the same grounds ADR-0001 killed the v1 code-shadows-html footgun: exactly one
+  source, both/neither throws `InvalidArgumentException`.
+
+## Consequences
+
+- The block is authoring-time only: `Block::markdown()` is the entire public
+  surface. There is no `markdown` type on the wire, so nothing downstream
+  (Vue, the component map, the wire-format docs) gains a branch.
+- A dev who needs raw, un-escaped HTML inside a document drops an `html` block
+  alongside — same trusted-input model, no new sanitizer.
+- Converter options/extensions are intentionally out of scope; they can be added
+  later as additive fluent methods without touching the wire format.

--- a/docs/adr/0002-markdown-block-compiles-to-html-wire-type.md
+++ b/docs/adr/0002-markdown-block-compiles-to-html-wire-type.md
@@ -38,9 +38,12 @@ apparent inconsistency by adding a client-side renderer.
   Markdown dependency, and would mean the wire carries un-compiled Markdown
   (raw source) to the browser — a larger, less-safe payload than the compiled,
   escaped HTML. It buys nothing over compiling in PHP.
-- **Silent precedence when both `content` and `file` are passed.** Rejected on
-  the same grounds ADR-0001 killed the v1 code-shadows-html footgun: exactly one
-  source, both/neither throws `InvalidArgumentException`.
+- **Two separate sources (`content` and `file` constructor params).** Rejected
+  in favour of a single `$content` source whose interpretation is switched by a
+  fluent `->file()` marker (`Block::markdown($content)` inline by default,
+  `Block::markdown($path)->file()` to read a file). Avoids the both/neither
+  ambiguity entirely instead of guarding it; an unreadable path under `->file()`
+  still throws `InvalidArgumentException` at serialize.
 
 ## Consequences
 

--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -53,6 +53,11 @@ abstract class Block
         return new ViewBlock($view, $data);
     }
 
+    public static function markdown(string|Stringable $content): MarkdownBlock
+    {
+        return new MarkdownBlock($content);
+    }
+
     public static function heading(string|Stringable $value): HeadingBlock
     {
         return new HeadingBlock($value);

--- a/src/Blocks/MarkdownBlock.php
+++ b/src/Blocks/MarkdownBlock.php
@@ -8,15 +8,20 @@ use Stringable;
 
 class MarkdownBlock extends Block
 {
+    private bool $isFile = false;
+
     public function __construct(
-        private readonly string|Stringable|null $content = null,
-        private readonly ?string $file = null,
-    ) {
-        if (($this->content === null) === ($this->file === null)) {
-            throw new InvalidArgumentException(
-                'A markdown block requires exactly one source: pass either content or file, not both or neither.',
-            );
-        }
+        private readonly string|Stringable $content,
+    ) {}
+
+    /**
+     * Treat the content as a filesystem path to a markdown file.
+     */
+    public function file(): self
+    {
+        $this->isFile = true;
+
+        return $this;
     }
 
     /**
@@ -32,12 +37,14 @@ class MarkdownBlock extends Block
 
     private function source(): string
     {
-        if ($this->content !== null) {
+        if (! $this->isFile) {
             return (string) $this->content;
         }
 
-        if (! is_file($this->file) || ($contents = @file_get_contents($this->file)) === false) {
-            throw new InvalidArgumentException("Unable to read markdown file [{$this->file}].");
+        $path = (string) $this->content;
+
+        if (! is_file($path) || ($contents = @file_get_contents($path)) === false) {
+            throw new InvalidArgumentException("Unable to read markdown file [{$path}].");
         }
 
         return $contents;

--- a/src/Blocks/MarkdownBlock.php
+++ b/src/Blocks/MarkdownBlock.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Blocks;
+
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use Stringable;
+
+class MarkdownBlock extends Block
+{
+    public function __construct(
+        private readonly string|Stringable|null $content = null,
+        private readonly ?string $file = null,
+    ) {
+        if (($this->content === null) === ($this->file === null)) {
+            throw new InvalidArgumentException(
+                'A markdown block requires exactly one source: pass either content or file, not both or neither.',
+            );
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => 'html',
+            'value' => Str::markdown($this->source()),
+        ];
+    }
+
+    private function source(): string
+    {
+        if ($this->content !== null) {
+            return (string) $this->content;
+        }
+
+        if (! is_file($this->file) || ($contents = @file_get_contents($this->file)) === false) {
+            throw new InvalidArgumentException("Unable to read markdown file [{$this->file}].");
+        }
+
+        return $contents;
+    }
+}

--- a/src/ModalResponse.php
+++ b/src/ModalResponse.php
@@ -55,6 +55,11 @@ class ModalResponse extends ActionResponse
         return self::stack([Block::view($view, $data)]);
     }
 
+    public static function markdown(string|Stringable $content): self
+    {
+        return self::stack([Block::markdown($content)]);
+    }
+
     public static function code(string|Stringable $value): self
     {
         return self::stack([Block::code($value)]);

--- a/tests/Blocks/MarkdownBlockTest.php
+++ b/tests/Blocks/MarkdownBlockTest.php
@@ -5,6 +5,7 @@ namespace Markwalet\NovaModalResponse\Tests\Blocks;
 use InvalidArgumentException;
 use Markwalet\NovaModalResponse\Blocks\Block;
 use Markwalet\NovaModalResponse\Blocks\MarkdownBlock;
+use Markwalet\NovaModalResponse\ModalResponse;
 use Markwalet\NovaModalResponse\Tests\TestCase;
 
 class MarkdownBlockTest extends TestCase
@@ -30,7 +31,7 @@ class MarkdownBlockTest extends TestCase
         file_put_contents($path, "# From file\n\nSome **bold** text.");
 
         try {
-            $block = Block::markdown(file: $path);
+            $block = Block::markdown($path)->file();
 
             $result = $block->toArray();
 
@@ -42,27 +43,24 @@ class MarkdownBlockTest extends TestCase
         }
     }
 
-    public function test_passing_both_content_and_file_throws(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        Block::markdown('# Inline', file: 'whatever.md');
-    }
-
-    public function test_passing_neither_content_nor_file_throws(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        Block::markdown();
-    }
-
     public function test_a_missing_file_throws_at_serialize(): void
     {
-        $block = Block::markdown(file: '/does/not/exist.md');
+        $block = Block::markdown('/does/not/exist.md')->file();
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to read markdown file');
 
         $block->toArray();
+    }
+
+    public function test_markdown_sugar_produces_a_single_html_block_stack(): void
+    {
+        $response = ModalResponse::markdown('# Title');
+
+        $this->assertSame([
+            'blocks' => [
+                ['type' => 'html', 'value' => "<h1>Title</h1>\n"],
+            ],
+        ], $response['modal']->payload);
     }
 }

--- a/tests/Blocks/MarkdownBlockTest.php
+++ b/tests/Blocks/MarkdownBlockTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Tests\Blocks;
+
+use InvalidArgumentException;
+use Markwalet\NovaModalResponse\Blocks\Block;
+use Markwalet\NovaModalResponse\Blocks\MarkdownBlock;
+use Markwalet\NovaModalResponse\Tests\TestCase;
+
+class MarkdownBlockTest extends TestCase
+{
+    public function test_factory_returns_a_markdown_block(): void
+    {
+        $this->assertInstanceOf(MarkdownBlock::class, Block::markdown('# Hi'));
+    }
+
+    public function test_it_compiles_inline_content_to_an_html_block(): void
+    {
+        $block = Block::markdown('# Title');
+
+        $result = $block->toArray();
+
+        $this->assertSame('html', $result['type']);
+        $this->assertStringContainsString('<h1>Title</h1>', $result['value']);
+    }
+
+    public function test_it_compiles_a_file_to_an_html_block(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'md').'.md';
+        file_put_contents($path, "# From file\n\nSome **bold** text.");
+
+        try {
+            $block = Block::markdown(file: $path);
+
+            $result = $block->toArray();
+
+            $this->assertSame('html', $result['type']);
+            $this->assertStringContainsString('<h1>From file</h1>', $result['value']);
+            $this->assertStringContainsString('<strong>bold</strong>', $result['value']);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function test_passing_both_content_and_file_throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Block::markdown('# Inline', file: 'whatever.md');
+    }
+
+    public function test_passing_neither_content_nor_file_throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Block::markdown();
+    }
+
+    public function test_a_missing_file_throws_at_serialize(): void
+    {
+        $block = Block::markdown(file: '/does/not/exist.md');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to read markdown file');
+
+        $block->toArray();
+    }
+}

--- a/workbench/app/Nova/Actions/ViewMarkdownAction.php
+++ b/workbench/app/Nova/Actions/ViewMarkdownAction.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Nova\Actions;
+
+use Illuminate\Support\Collection;
+use Laravel\Nova\Actions\Action;
+use Laravel\Nova\Actions\ActionResponse;
+use Laravel\Nova\Fields\ActionFields;
+use Markwalet\NovaModalResponse\Blocks\Block;
+use Markwalet\NovaModalResponse\ModalResponse;
+
+use function Orchestra\Testbench\workbench_path;
+
+class ViewMarkdownAction extends Action
+{
+    public $name = 'View markdown';
+
+    public $withoutConfirmation = true;
+
+    public $showInline = true;
+
+    public function handle(ActionFields $fields, Collection $models): Action|ActionResponse
+    {
+        return ModalResponse::stack([
+            Block::heading('Inline markdown')->small(),
+            Block::markdown(<<<'MD'
+                # Release notes
+
+                A markdown block compiles to an `html` block at serialize time.
+
+                - GitHub-flavored markdown via `Str::markdown()`
+                - **Bold**, *italic*, and `inline code`
+                - [Links](https://nova.laravel.com)
+
+                > Trusted-input model — same as the html block.
+                MD),
+            Block::divider(),
+            Block::heading('Markdown loaded from a file')->small(),
+            // testbench does not resolve this package's base_path(), so the demo
+            // fixture lives in the workbench and is loaded via its real path.
+            Block::markdown(file: workbench_path('resources/demo.md')),
+        ])
+            ->title('Demo — markdown block')
+            ->closeButton('Close');
+    }
+}

--- a/workbench/app/Nova/Actions/ViewMarkdownAction.php
+++ b/workbench/app/Nova/Actions/ViewMarkdownAction.php
@@ -40,7 +40,7 @@ class ViewMarkdownAction extends Action
             Block::heading('Markdown loaded from a file')->small(),
             // testbench does not resolve this package's base_path(), so the demo
             // fixture lives in the workbench and is loaded via its real path.
-            Block::markdown(file: workbench_path('resources/demo.md')),
+            Block::markdown(workbench_path('resources/demo.md'))->file(),
         ])
             ->title('Demo — markdown block')
             ->closeButton('Close');

--- a/workbench/app/Nova/Actions/ViewTextStackAction.php
+++ b/workbench/app/Nova/Actions/ViewTextStackAction.php
@@ -84,6 +84,9 @@ class ViewTextStackAction extends Action
                 'body' => 'This card is a Blade view compiled to HTML and serialized as an html block.',
             ]),
             Block::divider(),
+            Block::heading('Markdown (compiles to an html block)')->small(),
+            Block::markdown("# Inline markdown\n\nCompiled to HTML by `Str::markdown()` — **bold**, *italic*, and a [link](https://nova.laravel.com)."),
+            Block::divider(),
             Block::heading('JSON payload')->small(),
             Block::json([
                 'ok' => true,

--- a/workbench/app/Nova/User.php
+++ b/workbench/app/Nova/User.php
@@ -16,6 +16,7 @@ use Laravel\Nova\Lenses\Lens;
 use Laravel\Nova\Panel;
 use Laravel\Nova\ResourceTool;
 use Workbench\App\Nova\Actions\ViewBladeViewAction;
+use Workbench\App\Nova\Actions\ViewMarkdownAction;
 use Workbench\App\Nova\Actions\ViewTextStackAction;
 use Workbench\App\Nova\Actions\ViewWithoutHighlightingAction;
 
@@ -114,6 +115,7 @@ class User extends Resource
             new ViewTextStackAction,
             new ViewBladeViewAction,
             new ViewWithoutHighlightingAction,
+            new ViewMarkdownAction,
         ];
     }
 }

--- a/workbench/resources/demo.md
+++ b/workbench/resources/demo.md
@@ -1,0 +1,21 @@
+# Markdown loaded from a file
+
+This document is read from disk at serialize time and compiled to HTML by
+`Str::markdown()`.
+
+## Features
+
+- GitHub-flavored markdown
+- **Bold**, *italic*, and `inline code`
+- [Links](https://nova.laravel.com)
+
+```php
+Block::markdown(file: workbench_path('resources/demo.md'));
+```
+
+> Blockquotes work too.
+
+| Column | Value |
+| ------ | ----- |
+| Source | file  |
+| Type   | html  |


### PR DESCRIPTION
Adds a `Block::markdown()` block that compiles Markdown to HTML at serialize time.

## What

- `src/Blocks/MarkdownBlock.php` extends `Block`; `Block::markdown(string|Stringable|null $content = null, ?string $file = null)` factory.
- Compiles with Laravel's `Str::markdown()` (bundled `league/commonmark`, GFM, safe-by-default) and emits `{ type: 'html', value: '<compiled html>' }` at `toArray()`.
- Exactly-one-source contract: passing both `content` and `file`, or neither, throws `InvalidArgumentException`. A missing/unreadable file throws at serialize.
- No new PHP or JS dependency, no new Vue component (reuses `HtmlBlock.vue`). `resources/js` untouched, so no `dist` rebuild.

## Tests

5 cases (inline compile, file compile, both-passed throw, neither-passed throw, missing-file throw). Full suite: 81 passing, Pint clean.

## ADR

Added `docs/adr/0002-markdown-block-compiles-to-html-wire-type.md`. The markdown-compiles-to-the-`html`-wire-type choice deliberately breaks the otherwise-uniform `{Type}Block ↔ {Type}Block.vue ↔ type` convention (a `MarkdownBlock.php` with no `MarkdownBlock.vue` and no `markdown` type on the wire). That is hard-to-reverse and a future reader would otherwise be tempted to "fix" the asymmetry by adding a client-side renderer, so it earns an ADR — distinct from small additive block options (e.g. badge variants) that don't.

## Workbench demos (for review)

- Markdown section added to `ViewTextStackAction`'s all-blocks stack.
- New `ViewMarkdownAction` (registered in `User::actions()`) shows inline markdown AND a `file:`-loaded doc. testbench's `base_path()` doesn't resolve to this package, so the file demo loads a fixture (`workbench/resources/demo.md`) via `workbench_path()`.

Closes #58