### PR TITLE
Replace inline spread boolean with alignment knob

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,6 +28,10 @@ _Avoid_: blade block, partial, template
 A block (type `inline`) that lays a set of **atoms** on a single horizontal row, instead of stacking them vertically like the rest of the body. Built in PHP via `Block::inline([...])`. The only block that may contain other blocks.
 _Avoid_: row, inline block content, flex container
 
+**Alignment**:
+How an inline group distributes its atoms along the row. Four values: `default` (packed to the start, the implicit one), `spread` (first atom at the start, last at the end, gaps pushed between them), `center` (atoms clustered in the middle), `end` (packed to the trailing edge). Exposed in PHP as zero-arg fluent methods on the inline block (`->spread()`, `->center()`, `->end()`) or via the explicit `->alignment()` setter, which accepts either a value string or an `Alignment` enum case; `default` is what you get if none is called. Mirrors the **variant** pattern: one knob, one implicit value, named fluent setters. Main-axis only — atoms are always vertically centred regardless. `end` is direction-aware (the trailing edge, so the left under RTL), not physically "right".
+_Avoid_: justify, distribution, spacing, right
+
 **Atom**:
 A block permitted inside an **inline group**: `text`, `badge`, `icon`, `link`. Marked in PHP by the `Inlineable` interface — a promise about layout only (it may sit on a horizontal row); it does not change the block's serialized output. Blocks that are not atoms (e.g. `heading`, `code`, `divider`) are rejected from an inline group, as is a nested inline group.
 _Avoid_: inline element, item, child block

--- a/resources/js/components/InlineBlock.vue
+++ b/resources/js/components/InlineBlock.vue
@@ -2,7 +2,7 @@
     <div class="py-3 px-8">
         <div
             class="flex flex-wrap items-center gap-x-2 gap-y-1"
-            :class="block.spread ? 'justify-between' : 'justify-start'"
+            :class="alignmentClass"
         >
             <component
                 v-for="(atom, index) in (block.value ?? [])"
@@ -17,6 +17,13 @@
 <script>
 import { blockComponents } from './blockComponents.js'
 
+const ALIGNMENT_CLASSES = {
+    default: 'justify-start',
+    spread: 'justify-between',
+    center: 'justify-center',
+    end: 'justify-end',
+}
+
 export default {
     props: {
         block: { type: Object, required: true },
@@ -26,6 +33,12 @@ export default {
         return {
             blockComponents,
         }
+    },
+
+    computed: {
+        alignmentClass() {
+            return ALIGNMENT_CLASSES[this.block.alignment] ?? ALIGNMENT_CLASSES.default
+        },
     },
 }
 </script>

--- a/src/Blocks/InlineBlock.php
+++ b/src/Blocks/InlineBlock.php
@@ -3,11 +3,12 @@
 namespace Markwalet\NovaModalResponse\Blocks;
 
 use InvalidArgumentException;
+use Markwalet\NovaModalResponse\Enums\Alignment;
 use Stringable;
 
 class InlineBlock extends Block
 {
-    private bool $spread = false;
+    private Alignment $alignment = Alignment::DEFAULT;
 
     /** @var list<Block&Inlineable> */
     private readonly array $atoms;
@@ -34,7 +35,24 @@ class InlineBlock extends Block
 
     public function spread(): self
     {
-        $this->spread = true;
+        return $this->alignment(Alignment::SPREAD);
+    }
+
+    public function center(): self
+    {
+        return $this->alignment(Alignment::CENTER);
+    }
+
+    public function end(): self
+    {
+        return $this->alignment(Alignment::END);
+    }
+
+    public function alignment(string|Alignment $alignment): self
+    {
+        $this->alignment = $alignment instanceof Alignment
+            ? $alignment
+            : Alignment::from($alignment);
 
         return $this;
     }
@@ -46,7 +64,7 @@ class InlineBlock extends Block
     {
         return [
             'type' => 'inline',
-            'spread' => $this->spread,
+            'alignment' => $this->alignment->value,
             'value' => array_map(static fn (Block $atom): array => $atom->toArray(), $this->atoms),
         ];
     }

--- a/src/Enums/Alignment.php
+++ b/src/Enums/Alignment.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Enums;
+
+enum Alignment: string
+{
+    case DEFAULT = 'default';
+    case SPREAD = 'spread';
+    case CENTER = 'center';
+    case END = 'end';
+}

--- a/tests/Blocks/IconBlockTest.php
+++ b/tests/Blocks/IconBlockTest.php
@@ -58,7 +58,7 @@ class IconBlockTest extends TestCase
 
         $this->assertSame([
             'type' => 'inline',
-            'spread' => false,
+            'alignment' => 'default',
             'value' => [
                 ['type' => 'icon', 'value' => 'check-circle', 'variant' => 'success'],
                 ['type' => 'text', 'value' => 'Done'],

--- a/tests/Blocks/InlineBlockTest.php
+++ b/tests/Blocks/InlineBlockTest.php
@@ -5,7 +5,9 @@ namespace Markwalet\NovaModalResponse\Tests\Blocks;
 use InvalidArgumentException;
 use Markwalet\NovaModalResponse\Blocks\Block;
 use Markwalet\NovaModalResponse\Blocks\InlineBlock;
+use Markwalet\NovaModalResponse\Enums\Alignment;
 use Markwalet\NovaModalResponse\Tests\TestCase;
+use ValueError;
 
 class InlineBlockTest extends TestCase
 {
@@ -16,7 +18,7 @@ class InlineBlockTest extends TestCase
         $this->assertInstanceOf(InlineBlock::class, $block);
         $this->assertSame([
             'type' => 'inline',
-            'spread' => false,
+            'alignment' => 'default',
             'value' => [
                 ['type' => 'text', 'value' => 'Status'],
                 ['type' => 'badge', 'value' => 'Active', 'variant' => 'success'],
@@ -34,18 +36,67 @@ class InlineBlockTest extends TestCase
         );
     }
 
-    public function test_spread_flips_the_layout_knob(): void
+    public function test_spread_sets_the_alignment_knob(): void
     {
         $block = Block::inline([Block::text('key'), Block::badge('value')])->spread();
 
         $this->assertSame([
             'type' => 'inline',
-            'spread' => true,
+            'alignment' => 'spread',
             'value' => [
                 ['type' => 'text', 'value' => 'key'],
                 ['type' => 'badge', 'value' => 'value', 'variant' => 'default'],
             ],
         ], $block->toArray());
+    }
+
+    public function test_center_sets_the_alignment_knob(): void
+    {
+        $block = Block::inline([Block::text('key')])->center();
+
+        $this->assertSame('center', $block->toArray()['alignment']);
+    }
+
+    public function test_end_sets_the_alignment_knob(): void
+    {
+        $block = Block::inline([Block::text('key')])->end();
+
+        $this->assertSame('end', $block->toArray()['alignment']);
+    }
+
+    public function test_alignment_defaults_to_default(): void
+    {
+        $block = Block::inline([Block::text('key')]);
+
+        $this->assertSame('default', $block->toArray()['alignment']);
+    }
+
+    public function test_alignment_accepts_a_string(): void
+    {
+        $block = Block::inline([Block::text('key')])->alignment('center');
+
+        $this->assertSame('center', $block->toArray()['alignment']);
+    }
+
+    public function test_alignment_accepts_an_enum(): void
+    {
+        $block = Block::inline([Block::text('key')])->alignment(Alignment::CENTER);
+
+        $this->assertSame('center', $block->toArray()['alignment']);
+    }
+
+    public function test_alignment_rejects_an_unknown_string(): void
+    {
+        $this->expectException(ValueError::class);
+
+        Block::inline([Block::text('key')])->alignment('diagonal');
+    }
+
+    public function test_the_last_alignment_call_wins(): void
+    {
+        $block = Block::inline([Block::text('key')])->spread()->center()->end();
+
+        $this->assertSame('end', $block->toArray()['alignment']);
     }
 
     public function test_atoms_serialize_through_their_own_to_array(): void
@@ -62,7 +113,7 @@ class InlineBlockTest extends TestCase
     {
         $this->assertSame([
             'type' => 'inline',
-            'spread' => false,
+            'alignment' => 'default',
             'value' => [],
         ], Block::inline([])->toArray());
     }
@@ -73,7 +124,7 @@ class InlineBlockTest extends TestCase
 
         $this->assertSame([
             'type' => 'inline',
-            'spread' => false,
+            'alignment' => 'default',
             'value' => [
                 ['type' => 'text', 'value' => 'Hello'],
                 ['type' => 'badge', 'value' => 'New', 'variant' => 'default'],

--- a/tests/Blocks/LinkBlockTest.php
+++ b/tests/Blocks/LinkBlockTest.php
@@ -76,7 +76,7 @@ class LinkBlockTest extends TestCase
 
         $this->assertSame([
             'type' => 'inline',
-            'spread' => false,
+            'alignment' => 'default',
             'value' => [
                 ['type' => 'text', 'value' => 'See'],
                 ['type' => 'link', 'value' => 'Docs', 'href' => 'https://example.test', 'appearance' => 'link', 'newTab' => true],

--- a/tests/ModalResponseTest.php
+++ b/tests/ModalResponseTest.php
@@ -66,7 +66,7 @@ class ModalResponseTest extends TestCase
             'blocks' => [
                 [
                     'type' => 'inline',
-                    'spread' => true,
+                    'alignment' => 'spread',
                     'value' => [
                         ['type' => 'text', 'value' => 'Status'],
                         ['type' => 'badge', 'value' => 'Active', 'variant' => 'success'],

--- a/workbench/app/Nova/Actions/ViewTextStackAction.php
+++ b/workbench/app/Nova/Actions/ViewTextStackAction.php
@@ -55,11 +55,26 @@ class ViewTextStackAction extends Action
                 Block::icon('check-circle')->success(),
                 Block::badge('Published')->success(),
             ]),
+            Block::heading('Inline group — default alignment')->small(),
+            Block::inline([
+                Block::text('Deployment'),
+                Block::badge('Live')->success(),
+            ]),
             Block::heading('Inline group — spread (key/value row)')->small(),
             Block::inline([
                 Block::text('Deployment'),
                 Block::badge('Live')->success(),
             ])->spread(),
+            Block::heading('Inline group — center alignment')->small(),
+            Block::inline([
+                Block::text('Deployment'),
+                Block::badge('Live')->success(),
+            ])->center(),
+            Block::heading('Inline group — end alignment')->small(),
+            Block::inline([
+                Block::text('Deployment'),
+                Block::badge('Live')->success(),
+            ])->end(),
             Block::divider(),
             Block::heading('Links')->small(),
             Block::link('Same-tab link', 'https://nova.laravel.com'),


### PR DESCRIPTION
Replaces the inline group's `->spread()` boolean toggle with an **alignment** knob that mirrors the existing `variant` pattern: a single string field defaulting to `default`, with zero-arg fluent setters (`->spread()`, `->center()`, `->end()`) written through one private setter so the last call wins.

The Vue inline renderer maps the value to a `justify-*` class via a lookup table with a fallback (mirroring `BadgeBlock`'s `VARIANT_CLASSES`): `default→justify-start`, `spread→justify-between`, `center→justify-center`, `end→justify-end`, unknown/missing→`justify-start`.

**Breaking payload change**: the serialized inline block drops the `spread` boolean key and gains an `alignment` string key. The bundled Vue renderer updates in lockstep; the only thing affected is a hypothetical third-party renderer reading `block.spread`.

Also adds the `Alignment` glossary entry to `CONTEXT.md`, expands the workbench demo to show all four alignments, and rebuilds `dist`.

Closes #61