### PR TITLE
Add collapsible block

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,7 +17,7 @@ The ordered sequence of blocks that makes up a modal's body content. Set via `Mo
 _Avoid_: body, content list, items
 
 **Block**:
-A single, typed unit of modal body content. Blocks render top-to-bottom in the given order. Built-in types: `text`, `heading`, `code`, `json`, `html`, `badge`, `divider`, `list`, `link`, `icon` (plus the **view block**, an authoring-only sugar that serializes as `html`).
+A single, typed unit of modal body content. Blocks render top-to-bottom in the given order. Built-in types: `text`, `heading`, `code`, `json`, `html`, `badge`, `divider`, `list`, `link`, `icon`, `collapsible` (plus the **view block**, an authoring-only sugar that serializes as `html`).
 _Avoid_: element, node, section
 
 **View block**:
@@ -47,6 +47,10 @@ _Avoid_: glyph, image, svg block
 **Link block**:
 An inline atom that renders an anchor to an `href`. It carries two independent knobs: a **link appearance** (how it looks) and `newTab` (where it opens — `->newTab()` opens a new, secure-by-default tab). A button-appearance link still navigates via its `href`; it does **not** trigger a Nova action.
 _Avoid_: button block, action button, CTA
+
+**Collapsible block**:
+A block (type `collapsible`) that pairs a **header** string with a nested **stack** of child blocks, rendered as a section the user expands and collapses by clicking the header. Built in PHP via `Block::collapsible($header, [...])`; children are normalized through `Block::normalize` (bare strings become text blocks) and dispatched through the same shared block-component map the stack and inline group use. Defaults to collapsed; `->expanded()` starts it open and `->collapsed()` is the explicit inverse (last call wins). Both accept an optional `bool|callable` (default `true`) so the open/closed state can be set programmatically, e.g. `->expanded($user->isAdmin())`. The initial open/closed state travels on the wire as an `expanded` boolean. Unlike an inline group, it is not top-level-only nor restricted to atoms — it may hold any blocks.
+_Avoid_: accordion, disclosure, drawer, section
 
 **Link appearance**:
 How a link block is rendered: `link` (the implicit one — bold, primary-coloured text) or `button` (button chrome). Cosmetic only; it does not change what the link does. Distinct from **variant**: appearance is shape, not colour.

--- a/resources/js/asset.js
+++ b/resources/js/asset.js
@@ -10,6 +10,7 @@ import JsonBlock from './components/JsonBlock'
 import InlineBlock from './components/InlineBlock'
 import LinkBlock from './components/LinkBlock'
 import IconBlock from './components/IconBlock'
+import CollapsibleBlock from './components/CollapsibleBlock'
 
 Nova.booting(app => {
     app.component('modal-response', ModalActionResponse)
@@ -24,4 +25,5 @@ Nova.booting(app => {
     app.component('modal-response-inline-block', InlineBlock)
     app.component('modal-response-link-block', LinkBlock)
     app.component('modal-response-icon-block', IconBlock)
+    app.component('modal-response-collapsible-block', CollapsibleBlock)
 });

--- a/resources/js/components/CollapsibleBlock.vue
+++ b/resources/js/components/CollapsibleBlock.vue
@@ -1,0 +1,51 @@
+<template>
+    <div class="py-3 px-8">
+        <button
+            type="button"
+            class="flex w-full items-center gap-x-2 text-left text-sm font-semibold text-gray-700 dark:text-gray-200"
+            :aria-expanded="expanded"
+            @click.prevent="toggle"
+        >
+            <Icon
+                :name="expanded ? 'chevron-down' : 'chevron-right'"
+                class="w-4 h-4 text-gray-500 dark:text-gray-400"
+            />
+            <span v-text="block.header" />
+        </button>
+
+        <div v-show="expanded" class="mt-2 -mx-8">
+            <component
+                v-for="(child, index) in (block.value ?? [])"
+                :is="blockComponents[child.type]"
+                :key="index"
+                :block="child"
+            />
+        </div>
+    </div>
+</template>
+
+<script>
+import { Icon } from 'laravel-nova-ui'
+import { blockComponents } from './blockComponents.js'
+
+export default {
+    components: { Icon },
+
+    props: {
+        block: { type: Object, required: true },
+    },
+
+    data() {
+        return {
+            blockComponents,
+            expanded: this.block.expanded ?? false,
+        }
+    },
+
+    methods: {
+        toggle() {
+            this.expanded = !this.expanded
+        },
+    },
+}
+</script>

--- a/resources/js/components/blockComponents.js
+++ b/resources/js/components/blockComponents.js
@@ -9,6 +9,7 @@ import JsonBlock from './JsonBlock.vue'
 import InlineBlock from './InlineBlock.vue'
 import LinkBlock from './LinkBlock.vue'
 import IconBlock from './IconBlock.vue'
+import CollapsibleBlock from './CollapsibleBlock.vue'
 
 // The single source of truth mapping a block `type` to the component that
 // renders it. Both the stack (ModalActionResponse.vue) and the inline group
@@ -25,4 +26,5 @@ export const blockComponents = {
     inline: InlineBlock,
     link: LinkBlock,
     icon: IconBlock,
+    collapsible: CollapsibleBlock,
 }

--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -95,6 +95,14 @@ abstract class Block
     }
 
     /**
+     * @param array<int, Block|string|StringableInterface> $blocks
+     */
+    public static function collapsible(string $header, array $blocks): CollapsibleBlock
+    {
+        return new CollapsibleBlock($header, $blocks);
+    }
+
+    /**
      * @param array<mixed> $value
      *
      * @throws JsonException

--- a/src/Blocks/CollapsibleBlock.php
+++ b/src/Blocks/CollapsibleBlock.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Blocks;
+
+use Stringable;
+
+class CollapsibleBlock extends Block
+{
+    private bool $expanded = false;
+
+    /** @var list<Block> */
+    private readonly array $blocks;
+
+    /**
+     * @param array<int, Block|string|Stringable> $blocks
+     */
+    public function __construct(private readonly string $header, array $blocks)
+    {
+        $this->blocks = array_map(
+            static fn (mixed $block): Block => Block::normalize($block),
+            array_values($blocks),
+        );
+    }
+
+    public function expanded(bool|callable $result = true): static
+    {
+        $this->expanded = (bool) value($result);
+
+        return $this;
+    }
+
+    public function collapsed(bool|callable $result = true): static
+    {
+        $this->expanded = ! value($result);
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => 'collapsible',
+            'header' => $this->header,
+            'expanded' => $this->expanded,
+            'value' => array_map(static fn (Block $block): array => $block->toArray(), $this->blocks),
+        ];
+    }
+}

--- a/tests/Blocks/CollapsibleBlockTest.php
+++ b/tests/Blocks/CollapsibleBlockTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Tests\Blocks;
+
+use InvalidArgumentException;
+use Markwalet\NovaModalResponse\Blocks\Block;
+use Markwalet\NovaModalResponse\Blocks\CollapsibleBlock;
+use Markwalet\NovaModalResponse\Tests\TestCase;
+
+class CollapsibleBlockTest extends TestCase
+{
+    public function test_factory_returns_a_collapsed_collapsible_block_by_default(): void
+    {
+        $block = Block::collapsible('Details', [Block::text('Some explanation')]);
+
+        $this->assertInstanceOf(CollapsibleBlock::class, $block);
+        $this->assertSame([
+            'type' => 'collapsible',
+            'header' => 'Details',
+            'expanded' => false,
+            'value' => [
+                ['type' => 'text', 'value' => 'Some explanation'],
+            ],
+        ], $block->toArray());
+    }
+
+    public function test_expanded_sets_the_open_state(): void
+    {
+        $block = Block::collapsible('Details', [Block::text('hi')])->expanded();
+
+        $this->assertTrue($block->toArray()['expanded']);
+    }
+
+    public function test_collapsed_sets_the_closed_state(): void
+    {
+        $block = Block::collapsible('Details', [Block::text('hi')])->collapsed();
+
+        $this->assertFalse($block->toArray()['expanded']);
+    }
+
+    public function test_expanded_false_collapses_the_block(): void
+    {
+        $block = Block::collapsible('Details', [Block::text('hi')])->expanded(false);
+
+        $this->assertFalse($block->toArray()['expanded']);
+    }
+
+    public function test_collapsed_false_expands_the_block(): void
+    {
+        $block = Block::collapsible('Details', [Block::text('hi')])->collapsed(false);
+
+        $this->assertTrue($block->toArray()['expanded']);
+    }
+
+    public function test_expanded_resolves_a_callable_argument(): void
+    {
+        $expanded = Block::collapsible('Details', [])->expanded(fn (): bool => true);
+        $collapsed = Block::collapsible('Details', [])->expanded(fn (): bool => false);
+
+        $this->assertTrue($expanded->toArray()['expanded']);
+        $this->assertFalse($collapsed->toArray()['expanded']);
+    }
+
+    public function test_collapsed_resolves_a_callable_argument(): void
+    {
+        $collapsed = Block::collapsible('Details', [])->collapsed(fn (): bool => true);
+        $expanded = Block::collapsible('Details', [])->collapsed(fn (): bool => false);
+
+        $this->assertFalse($collapsed->toArray()['expanded']);
+        $this->assertTrue($expanded->toArray()['expanded']);
+    }
+
+    public function test_last_state_call_wins(): void
+    {
+        $expandedLast = Block::collapsible('Details', [])->collapsed()->expanded();
+        $collapsedLast = Block::collapsible('Details', [])->expanded()->collapsed();
+
+        $this->assertTrue($expandedLast->toArray()['expanded']);
+        $this->assertFalse($collapsedLast->toArray()['expanded']);
+    }
+
+    public function test_children_serialize_through_their_own_to_array(): void
+    {
+        $block = Block::collapsible('Details', [
+            Block::text('Some explanation'),
+            Block::list(['One', 'Two']),
+            Block::badge('New')->success(),
+        ]);
+
+        $this->assertSame([
+            'type' => 'collapsible',
+            'header' => 'Details',
+            'expanded' => false,
+            'value' => [
+                ['type' => 'text', 'value' => 'Some explanation'],
+                ['type' => 'list', 'value' => ['One', 'Two'], 'ordered' => false],
+                ['type' => 'badge', 'value' => 'New', 'variant' => 'success'],
+            ],
+        ], $block->toArray());
+    }
+
+    public function test_bare_strings_are_coerced_to_text_blocks(): void
+    {
+        $block = Block::collapsible('Details', ['Hello', Block::badge('New')]);
+
+        $this->assertSame([
+            'type' => 'collapsible',
+            'header' => 'Details',
+            'expanded' => false,
+            'value' => [
+                ['type' => 'text', 'value' => 'Hello'],
+                ['type' => 'badge', 'value' => 'New', 'variant' => 'default'],
+            ],
+        ], $block->toArray());
+    }
+
+    public function test_an_empty_content_list_serializes_to_an_empty_value_list(): void
+    {
+        $this->assertSame([
+            'type' => 'collapsible',
+            'header' => 'Details',
+            'expanded' => false,
+            'value' => [],
+        ], Block::collapsible('Details', [])->toArray());
+    }
+
+    public function test_a_non_block_non_string_child_is_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Blocks must be Block instances or strings.');
+
+        Block::collapsible('Details', [42]);
+    }
+}

--- a/workbench/app/Nova/Actions/ViewTextStackAction.php
+++ b/workbench/app/Nova/Actions/ViewTextStackAction.php
@@ -84,6 +84,19 @@ class ViewTextStackAction extends Action
                 'body' => 'This card is a Blade view compiled to HTML and serialized as an html block.',
             ]),
             Block::divider(),
+            Block::heading('Collapsible — collapsed (default)')->small(),
+            Block::collapsible('Details', [
+                Block::text('Some explanation'),
+                Block::list(['One', 'Two']),
+                Block::badge('New')->success(),
+            ]),
+            Block::heading('Collapsible — expanded')->small(),
+            Block::collapsible('Details', [
+                Block::text('Some explanation'),
+                Block::list(['One', 'Two']),
+                Block::badge('New')->success(),
+            ])->expanded(),
+            Block::divider(),
             Block::heading('JSON payload')->small(),
             Block::json([
                 'ok' => true,


### PR DESCRIPTION
Adds a new `collapsible` block: a container pairing a header string with a nested stack of child blocks, rendered as a section the user expands/collapses by clicking the header.

- PHP `CollapsibleBlock` (extends `Block`) normalizing children via `Block::normalize` (bare strings coerced to text); `Block::collapsible($header, $blocks)` factory; fluent `->expanded()` / `->collapsed()` (last call wins, default collapsed). Wire shape: `{ type: 'collapsible', header, expanded, value }`.
- Vue `CollapsibleBlock.vue` — clickable header toggle initialized from `block.expanded`, children dispatched through the shared `blockComponents` map, chevron via `laravel-nova-ui` `Icon`. Registered in `blockComponents.js` and `asset.js` (`modal-response-collapsible-block`).
- Tests cover default-collapsed serialization, `->expanded()`/`->collapsed()`, last-call-wins, string coercion, nested-block serialization, empty list, and rejection of invalid children.
- `CONTEXT.md` block-type list + glossary entry. Rebuilt `dist`. Workbench demo (collapsed + expanded) added to `ViewTextStackAction`.

Closes #60