### PR TITLE
Add highlight argument to code()/json(), deprecate withoutSyntaxHighlighting()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased](https://github.com/markwalet/nova-modal-response/compare/v1.1.2...main)
 
+### Added
+- `ModalResponse::code()` and `ModalResponse::json()` accept a `highlight` argument to toggle syntax highlighting at construction (e.g. `ModalResponse::code($snippet, highlight: false)`)
+
+### Deprecated
+- `ModalResponse::withoutSyntaxHighlighting()` — pass `highlight: false` to `code()`/`json()` instead. Removed in v2.
+
 ## [v1.1.2 (2026-05-27)](https://github.com/markwalet/nova-modal-response/compare/v1.1.1...v1.1.2)
 
 ### Added

--- a/src/ModalResponse.php
+++ b/src/ModalResponse.php
@@ -13,27 +13,37 @@ class ModalResponse extends ActionResponse
      * Create a modal with a code snippet.
      *
      * @param string|Stringable $snippet
+     * @param bool $highlight Whether to syntax-highlight the snippet.
      * @return self
      */
-    public static function code(string|Stringable $snippet): self
+    public static function code(string|Stringable $snippet, bool $highlight = true): self
     {
-        return self::modal('modal-response', [
-            'code' => $snippet,
-        ]);
+        $payload = ['code' => $snippet];
+
+        if (! $highlight) {
+            $payload['highlight'] = false;
+        }
+
+        return self::modal('modal-response', $payload);
     }
 
     /**
      * Create a modal with a json payload.
      *
      * @param array<mixed> $data
+     * @param bool $highlight Whether to syntax-highlight the payload.
      * @return self
      * @throws JsonException
      */
-    public static function json(array $data): self
+    public static function json(array $data, bool $highlight = true): self
     {
-        return self::modal('modal-response', [
-            'code' => json_encode($data, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR),
-        ]);
+        $payload = ['code' => json_encode($data, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR)];
+
+        if (! $highlight) {
+            $payload['highlight'] = false;
+        }
+
+        return self::modal('modal-response', $payload);
     }
 
     /**
@@ -87,6 +97,8 @@ class ModalResponse extends ActionResponse
     /**
      * Disable syntax highlighting for json or code blocks.
      *
+     * @deprecated Pass `highlight: false` to ModalResponse::code() or ::json() instead.
+     *             This method is removed in v2.
      * @return self
      */
     public function withoutSyntaxHighlighting(): self

--- a/tests/ModalResponseTest.php
+++ b/tests/ModalResponseTest.php
@@ -29,6 +29,35 @@ class ModalResponseTest extends TestCase
         ], $modal->payload);
     }
 
+    public function test_code_response_highlights_by_default(): void
+    {
+        $response = ModalResponse::code('echo "test";');
+
+        $this->assertSame([
+            'code' => 'echo "test";',
+        ], $response['modal']->payload);
+    }
+
+    public function test_code_response_can_disable_highlighting_via_argument(): void
+    {
+        $response = ModalResponse::code('echo "test";', highlight: false);
+
+        $this->assertSame([
+            'code' => 'echo "test";',
+            'highlight' => false,
+        ], $response['modal']->payload);
+    }
+
+    public function test_json_response_can_disable_highlighting_via_argument(): void
+    {
+        $response = ModalResponse::json(['lorem' => 'ipsum'], highlight: false);
+
+        $this->assertSame([
+            'code' => json_encode(['lorem' => 'ipsum'], JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR),
+            'highlight' => false,
+        ], $response['modal']->payload);
+    }
+
     public function test_json_response_pretty_prints_the_payload(): void
     {
         $response = ModalResponse::json([


### PR DESCRIPTION
## What

Lets callers toggle syntax highlighting at construction time via a second argument on the two highlightable factories, and deprecates the standalone toggle method ahead of v2.

- `ModalResponse::code($snippet, highlight: false)` — disable highlighting for a code snippet
- `ModalResponse::json($data, highlight: false)` — disable highlighting for a JSON payload
- `withoutSyntaxHighlighting()` is now `@deprecated` (still functional) — it is removed in v2, where highlighting becomes a per-block concern

## Why

`withoutSyntaxHighlighting()` is a separate fluent call for what is really a property of the code/json content. Folding it into the factory argument is more direct, and deprecating the method now gives users a one-version warning before v2 drops it.

## Compatibility

Fully backward compatible. The new parameter defaults to `true`, and `highlight => false` is only written to the payload when explicitly disabled — so the default wire format is byte-identical to before. The existing `withoutSyntaxHighlighting()` behaviour is unchanged.

## Notes

- CHANGELOG updated (`Added` + `Deprecated`).
- QA green: PHPUnit (8 tests), PHPStan, Pint.
- No `dist/` rebuild (assets are built once per release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)