### PR TITLE
Add copy button to code & json modals

### DIFF
--- a/resources/css/asset.css
+++ b/resources/css/asset.css
@@ -5,3 +5,53 @@ html.dark {
 html {
     @import url('highlight.js/styles/github.css');
 }
+
+/* Copy button — self-contained so it doesn't depend on Nova's Tailwind bundle. */
+.nmr-code {
+    position: relative;
+}
+
+.nmr-code__copy {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    opacity: 0.4;
+    transition: opacity 150ms ease;
+}
+
+.nmr-code:hover .nmr-code__copy,
+.nmr-code:focus-within .nmr-code__copy {
+    opacity: 1;
+}
+
+.nmr-copy-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.375rem;
+    border-radius: 0.375rem;
+    color: #6b7280;
+    background-color: #ffffff;
+    transition: background-color 150ms ease, color 150ms ease;
+}
+
+.nmr-copy-button:hover {
+    background-color: #f3f4f6;
+    color: #374151;
+}
+
+.nmr-copy-button svg {
+    width: 1.25rem;
+    height: 1.25rem;
+    stroke-width: 2;
+}
+
+html.dark .nmr-copy-button {
+    color: #9ca3af;
+    background-color: #1f2937;
+}
+
+html.dark .nmr-copy-button:hover {
+    background-color: #374151;
+    color: #e5e7eb;
+}

--- a/resources/js/components/CopyButton.vue
+++ b/resources/js/components/CopyButton.vue
@@ -1,0 +1,50 @@
+<template>
+    <button
+        v-if="supported"
+        type="button"
+        @click.prevent="copy"
+        class="p-1.5 rounded text-gray-500 dark:text-gray-400 bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700"
+        :title="copied ? 'Copied' : 'Copy'"
+        dusk="copy-button"
+    >
+        <Icon :name="copied ? 'check' : 'clipboard'" class="w-4 h-4" />
+    </button>
+</template>
+
+<script>
+import { Icon } from 'laravel-nova-ui'
+
+export default {
+    components: { Icon },
+
+    props: {
+        value: { type: String, required: true },
+    },
+
+    data() {
+        return {
+            copied: false,
+            resetTimeout: null,
+        }
+    },
+
+    computed: {
+        supported() {
+            return typeof navigator !== 'undefined' && !!navigator.clipboard
+        },
+    },
+
+    methods: {
+        async copy() {
+            await navigator.clipboard.writeText(this.value)
+            this.copied = true
+            clearTimeout(this.resetTimeout)
+            this.resetTimeout = setTimeout(() => { this.copied = false }, 2000)
+        },
+    },
+
+    beforeUnmount() {
+        clearTimeout(this.resetTimeout)
+    },
+}
+</script>

--- a/resources/js/components/CopyButton.vue
+++ b/resources/js/components/CopyButton.vue
@@ -3,11 +3,11 @@
         v-if="supported"
         type="button"
         @click.prevent="copy"
-        class="p-1.5 rounded text-gray-500 dark:text-gray-400 bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700"
+        class="nmr-copy-button"
         :title="copied ? 'Copied' : 'Copy'"
         dusk="copy-button"
     >
-        <Icon :name="copied ? 'check' : 'clipboard'" class="w-4 h-4" />
+        <Icon :name="copied ? 'check' : 'clipboard'" />
     </button>
 </template>
 
@@ -32,6 +32,12 @@ export default {
         supported() {
             return typeof navigator !== 'undefined' && !!navigator.clipboard
         },
+    },
+
+    mounted() {
+        if (! this.supported) {
+            console.warn('[nova-modal-response] Copy button hidden: clipboard API unavailable (requires a secure context such as HTTPS or localhost).')
+        }
     },
 
     methods: {

--- a/resources/js/components/ModalActionResponse.vue
+++ b/resources/js/components/ModalActionResponse.vue
@@ -8,11 +8,8 @@
                 <ModalHeader v-text="data.title" />
 
                 <template v-if="data.code">
-                    <div class="relative group">
-                        <CopyButton
-                            :value="data.code"
-                            class="absolute top-2 right-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
-                        />
+                    <div class="nmr-code">
+                        <CopyButton :value="data.code" class="nmr-code__copy" />
                         <pre v-if="data.highlight === false"><code v-text="data.code" class="language-plaintext" ref="plaintextCode"></code></pre>
                         <highlightjs v-else autodetect :code="data.code" />
                     </div>

--- a/resources/js/components/ModalActionResponse.vue
+++ b/resources/js/components/ModalActionResponse.vue
@@ -8,8 +8,14 @@
                 <ModalHeader v-text="data.title" />
 
                 <template v-if="data.code">
-                    <pre v-if="data.highlight === false"><code v-text="data.code" class="language-plaintext" ref="plaintextCode"></code></pre>
-                    <highlightjs v-else autodetect :code="data.code" />
+                    <div class="relative group">
+                        <CopyButton
+                            :value="data.code"
+                            class="absolute top-2 right-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
+                        />
+                        <pre v-if="data.highlight === false"><code v-text="data.code" class="language-plaintext" ref="plaintextCode"></code></pre>
+                        <highlightjs v-else autodetect :code="data.code" />
+                    </div>
                 </template>
                 <div v-else class="py-3 px-8">
                     <div v-if="data.html" v-html="data.html"/>
@@ -38,10 +44,12 @@
 import hljs from 'highlight.js/lib/common';
 import hljsVuePlugin from "@highlightjs/vue-plugin";
 import { Button } from 'laravel-nova-ui'
+import CopyButton from './CopyButton.vue'
 
 export default {
     components: {
         Button,
+        CopyButton,
         highlightjs: hljsVuePlugin.component
     },
 


### PR DESCRIPTION
Adds an always-on copy-to-clipboard button to code/json modal content on the v1 line. Closes #76.

## What

- New **`CopyButton.vue`** — the canonical copy button: clipboard write + clipboard→check feedback (~2s), using nova-ui `Icon`. No new dependency (`laravel-nova-ui` already imported).
- Mounted in `ModalActionResponse.vue` in the content's top-right corner. Hover-reveal, plus `group-focus-within` so it's keyboard-reachable.
- Copies `data.code` **verbatim** (json's pretty-printed wire string is copied as-is — WYSIWYG, no re-encode).
- Wraps both the highlight-off plaintext branch and the highlighted branch.
- Rendered only when `navigator.clipboard` exists — hidden in insecure contexts, no dead button.

## Scope

- v1 only, frontend-only. No PHP / wire / API change.
- Per repo convention, `dist/` is **not** rebuilt or committed — only `resources/` is edited; assets build at release.

## QA

- `vendor/bin/pint --test` ✅
- `vendor/bin/phpstan analyse` ✅
- `vendor/bin/phpunit` ✅ (8 tests, unchanged — no wire change)