### PR TITLE
Wire copy button into code & json blocks

### DIFF
--- a/resources/js/components/CodeBlock.vue
+++ b/resources/js/components/CodeBlock.vue
@@ -1,17 +1,22 @@
 <template>
-    <template v-if="block.highlight === false">
-        <pre><code ref="plaintextCode" class="language-plaintext" v-text="block.value" /></pre>
-    </template>
-    <highlightjs v-else-if="block.language" :language="block.language" :code="block.value" />
-    <highlightjs v-else autodetect :code="block.value" />
+    <div class="nmr-code">
+        <CopyButton :value="block.value" class="nmr-code__copy" />
+        <template v-if="block.highlight === false">
+            <pre><code ref="plaintextCode" class="language-plaintext" v-text="block.value" /></pre>
+        </template>
+        <highlightjs v-else-if="block.language" :language="block.language" :code="block.value" />
+        <highlightjs v-else autodetect :code="block.value" />
+    </div>
 </template>
 
 <script>
 import hljs from 'highlight.js/lib/common'
 import hljsVuePlugin from '@highlightjs/vue-plugin'
+import CopyButton from './CopyButton.vue'
 
 export default {
     components: {
+        CopyButton,
         highlightjs: hljsVuePlugin.component,
     },
 

--- a/resources/js/components/JsonBlock.vue
+++ b/resources/js/components/JsonBlock.vue
@@ -1,16 +1,21 @@
 <template>
-    <template v-if="block.highlight === false">
-        <pre><code ref="plaintextCode" class="language-plaintext" v-text="block.value" /></pre>
-    </template>
-    <highlightjs v-else language="json" :code="block.value" />
+    <div class="nmr-code">
+        <CopyButton :value="block.value" class="nmr-code__copy" />
+        <template v-if="block.highlight === false">
+            <pre><code ref="plaintextCode" class="language-plaintext" v-text="block.value" /></pre>
+        </template>
+        <highlightjs v-else language="json" :code="block.value" />
+    </div>
 </template>
 
 <script>
 import hljs from 'highlight.js/lib/common'
 import hljsVuePlugin from '@highlightjs/vue-plugin'
+import CopyButton from './CopyButton.vue'
 
 export default {
     components: {
+        CopyButton,
         highlightjs: hljsVuePlugin.component,
     },
 


### PR DESCRIPTION
Wires the copy-to-clipboard button into the v2 `code` and `json` **blocks**. Closes #77.

## What

- Wrapped the entire template of `CodeBlock.vue` and `JsonBlock.vue` in a positioned `.nmr-code` container hosting `CopyButton` (`.nmr-code__copy`), so the button covers **all** render branches — highlight-off plaintext, explicit `language`, and autodetect.
- Reuses the canonical `CopyButton.vue` (arrived on `v2` via the `main`→`v2` merge) and its self-contained `.nmr-*` CSS. Copies `block.value` verbatim, hover/focus-within reveal, hidden when `navigator.clipboard` is absent.
- Not a wire block → **not** registered in `blockComponents.js`.

## Scope

- v2 only, frontend-only. No PHP, no wire change, no `toArray()` change.
- `code`/`json` blocks only; other blocks untouched.
- Per convention, `dist/` is not rebuilt or committed — only `resources/` edited; assets build at release.

## QA

- `vendor/bin/pint --test` ✅
- `vendor/bin/phpstan analyse` ✅
- `vendor/bin/phpunit` ✅ (108 tests — `CodeBlockTest`/`JsonBlockTest` green, untouched)

Sub-issue of the v2.0 roadmap (#21).