### PR TITLE
Add tabs block

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -60,6 +60,14 @@ _Avoid_: button block, action button, CTA
 A block (type `collapsible`) that pairs a **header** string with a nested **stack** of child blocks, rendered as a section the user expands and collapses by clicking the header. Built in PHP via `Block::collapsible($header, [...])`; children are normalized through `Block::normalize` (bare strings become text blocks) and dispatched through the same shared block-component map the stack and inline group use. Defaults to collapsed; `->expanded()` starts it open and `->collapsed()` is the explicit inverse (last call wins). Both accept an optional `bool|callable` (default `true`) so the open/closed state can be set programmatically, e.g. `->expanded($user->isAdmin())`. The initial open/closed state travels on the wire as an `expanded` boolean. Unlike an inline group, it is not top-level-only nor restricted to atoms — it may hold any blocks.
 _Avoid_: accordion, disclosure, drawer, section
 
+**Tabs block**:
+A block (type `tabs`) that holds an ordered set of **tabs**, of which exactly one is visible at a time; clicking a label in the header bar switches the visible panel. Built in PHP via `Block::tabs([...])`, with `ModalResponse::tabs([...])` sugar to render a tabbed interface as the whole modal body. The array is normalized to **Tab** value objects: a `Tab` instance passes through, a `string => array` entry becomes `Block::tab($label, $blocks)`, and anything else throws. Like the **collapsible block** it is block-level (not an **atom**) and may hold any blocks, nesting included. Renders with Nova's own `tab-group`/`tab-menu`/`tab-item`/`tab-card` styling (that CSS ships in Nova's `app.css`) and manages the active tab itself in Vue — it does not import Nova's tab components, which Nova does not export.
+_Avoid_: tab group, tab panel, accordion
+
+**Tab**:
+One entry in a **tabs block**: a cosmetic string **label** paired with a nested **stack** of child blocks (normalized through `Block::normalize`; bare strings become text blocks). Built via `Block::tab($label, [...])`. Identified by its position (index) in the tabs block, never by its label — so two tabs may share a label. `->active(bool|callable $result = true)` marks it the initially-visible tab (mirrors the collapsible's `->expanded()`); if several are marked active the last in order wins, and if none is, the first tab opens. A Tab is an internal value object of the tabs block, **not** an independently renderable block — its serialized node carries `label`/`active`/`value` and deliberately no `type` key.
+_Avoid_: panel, page, section, slug
+
 **Link appearance**:
 How a link block is rendered: `link` (the implicit one — bold, primary-coloured text) or `button` (button chrome). Cosmetic only; it does not change what the link does. Distinct from **variant**: appearance is shape, not colour.
 _Avoid_: link variant, link style, link kind

--- a/resources/js/components/TabsBlock.vue
+++ b/resources/js/components/TabsBlock.vue
@@ -1,0 +1,74 @@
+<template>
+    <div class="tab-group py-3 px-8">
+        <div class="tab-card">
+            <div
+                class="tab-menu divide-x dark:divide-gray-700 border-l-gray-200 border-r-gray-200 border-t-gray-200 border-b-gray-200 dark:border-l-gray-700 dark:border-r-gray-700 dark:border-t-gray-700 dark:border-b-gray-700"
+                role="tablist"
+            >
+                <button
+                    v-for="(tab, index) in tabs"
+                    :key="index"
+                    type="button"
+                    class="tab-item"
+                    :class="[
+                        index === activeIndex
+                            ? 'active text-primary-500 font-bold border-b-2 !border-b-primary-500'
+                            : 'text-gray-600 hover:text-gray-800 dark:text-gray-400 hover:dark:text-gray-200',
+                    ]"
+                    role="tab"
+                    :aria-selected="index === activeIndex"
+                    @click.prevent="activeIndex = index"
+                >
+                    <span class="capitalize">{{ tab.label }}</span>
+                </button>
+            </div>
+
+            <div v-if="activeTab" class="mt-2 -mx-8">
+                <component
+                    v-for="(child, childIndex) in (activeTab.value ?? [])"
+                    :is="blockComponents[child.type]"
+                    :key="childIndex"
+                    :block="child"
+                />
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import { blockComponents } from './blockComponents.js'
+
+function resolveInitialIndex(tabs) {
+    let index = 0
+
+    tabs.forEach((tab, i) => {
+        if (tab.active === true) {
+            index = i
+        }
+    })
+
+    return index
+}
+
+export default {
+    props: {
+        block: { type: Object, required: true },
+    },
+
+    data() {
+        const tabs = this.block.value ?? []
+
+        return {
+            blockComponents,
+            tabs,
+            activeIndex: resolveInitialIndex(tabs),
+        }
+    },
+
+    computed: {
+        activeTab() {
+            return this.tabs[this.activeIndex] ?? null
+        },
+    },
+}
+</script>

--- a/resources/js/components/TabsBlock.vue
+++ b/resources/js/components/TabsBlock.vue
@@ -1,36 +1,34 @@
 <template>
-    <div class="tab-group py-3 px-8">
-        <div class="tab-card">
-            <div
-                class="tab-menu divide-x dark:divide-gray-700 border-l-gray-200 border-r-gray-200 border-t-gray-200 border-b-gray-200 dark:border-l-gray-700 dark:border-r-gray-700 dark:border-t-gray-700 dark:border-b-gray-700"
-                role="tablist"
+    <div>
+        <div
+            class="flex border-b border-gray-200 dark:border-gray-700"
+            role="tablist"
+        >
+            <button
+                v-for="(tab, index) in tabs"
+                :key="index"
+                type="button"
+                class="px-6 py-3 text-sm focus:outline-none border-b-2"
+                :class="[
+                    index === activeIndex
+                        ? 'text-primary-500 font-bold border-primary-500'
+                        : 'text-gray-600 hover:text-gray-800 dark:text-gray-400 hover:dark:text-gray-200 border-transparent font-semibold',
+                ]"
+                role="tab"
+                :aria-selected="index === activeIndex"
+                @click.prevent="activeIndex = index"
             >
-                <button
-                    v-for="(tab, index) in tabs"
-                    :key="index"
-                    type="button"
-                    class="tab-item"
-                    :class="[
-                        index === activeIndex
-                            ? 'active text-primary-500 font-bold border-b-2 !border-b-primary-500'
-                            : 'text-gray-600 hover:text-gray-800 dark:text-gray-400 hover:dark:text-gray-200',
-                    ]"
-                    role="tab"
-                    :aria-selected="index === activeIndex"
-                    @click.prevent="activeIndex = index"
-                >
-                    <span class="capitalize">{{ tab.label }}</span>
-                </button>
-            </div>
+                <span class="capitalize">{{ tab.label }}</span>
+            </button>
+        </div>
 
-            <div v-if="activeTab" class="mt-2 -mx-8">
-                <component
-                    v-for="(child, childIndex) in (activeTab.value ?? [])"
-                    :is="blockComponents[child.type]"
-                    :key="childIndex"
-                    :block="child"
-                />
-            </div>
+        <div v-if="activeTab">
+            <component
+                v-for="(child, childIndex) in (activeTab.value ?? [])"
+                :is="blockComponents[child.type]"
+                :key="childIndex"
+                :block="child"
+            />
         </div>
     </div>
 </template>

--- a/resources/js/components/blockComponents.js
+++ b/resources/js/components/blockComponents.js
@@ -10,6 +10,7 @@ import InlineBlock from './InlineBlock.vue'
 import LinkBlock from './LinkBlock.vue'
 import IconBlock from './IconBlock.vue'
 import CollapsibleBlock from './CollapsibleBlock.vue'
+import TabsBlock from './TabsBlock.vue'
 
 // The single source of truth mapping a block `type` to the component that
 // renders it. Both the stack (ModalActionResponse.vue) and the inline group
@@ -27,4 +28,5 @@ export const blockComponents = {
     link: LinkBlock,
     icon: IconBlock,
     collapsible: CollapsibleBlock,
+    tabs: TabsBlock,
 }

--- a/src/Block.php
+++ b/src/Block.php
@@ -18,6 +18,8 @@ use Markwalet\NovaModalResponse\Blocks\LinkBlock;
 use Markwalet\NovaModalResponse\Blocks\ListBlock;
 use Markwalet\NovaModalResponse\Blocks\MarkdownBlock;
 use Markwalet\NovaModalResponse\Blocks\Renderable;
+use Markwalet\NovaModalResponse\Blocks\Tab;
+use Markwalet\NovaModalResponse\Blocks\TabsBlock;
 use Markwalet\NovaModalResponse\Blocks\TextBlock;
 use Markwalet\NovaModalResponse\Blocks\ViewBlock;
 use Stringable as StringableInterface;
@@ -131,5 +133,21 @@ final class Block
     public static function json(array $value): JsonBlock
     {
         return new JsonBlock($value);
+    }
+
+    /**
+     * @param array<int, Renderable|string|StringableInterface> $blocks
+     */
+    public static function tab(string $label, array $blocks): Tab
+    {
+        return new Tab($label, $blocks);
+    }
+
+    /**
+     * @param array<mixed> $tabs
+     */
+    public static function tabs(array $tabs): TabsBlock
+    {
+        return new TabsBlock($tabs);
     }
 }

--- a/src/Blocks/Tab.php
+++ b/src/Blocks/Tab.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Blocks;
+
+use Markwalet\NovaModalResponse\Block;
+use Stringable;
+
+/**
+ * A single entry in a tabs block: a cosmetic label paired with a nested stack
+ * of child blocks. Internal value object of the tabs block — deliberately NOT
+ * a Renderable, so it is never dispatched through the block-component map.
+ */
+class Tab
+{
+    private bool $active = false;
+
+    /** @var list<Renderable> */
+    private readonly array $blocks;
+
+    /**
+     * @param array<int, Renderable|string|Stringable> $blocks
+     */
+    public function __construct(private readonly string $label, array $blocks)
+    {
+        $this->blocks = array_map(
+            static fn (mixed $block): Renderable => Block::normalize($block),
+            array_values($blocks),
+        );
+    }
+
+    public function active(bool|callable $result = true): static
+    {
+        $this->active = (bool) value($result);
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'label' => $this->label,
+            'active' => $this->active,
+            'value' => array_map(static fn (Renderable $block): array => $block->toArray(), $this->blocks),
+        ];
+    }
+}

--- a/src/Blocks/TabsBlock.php
+++ b/src/Blocks/TabsBlock.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Blocks;
+
+use InvalidArgumentException;
+use Markwalet\NovaModalResponse\Block;
+
+class TabsBlock implements Renderable
+{
+    /** @var list<Tab> */
+    private readonly array $tabs;
+
+    /**
+     * @param array<mixed> $tabs
+     */
+    public function __construct(array $tabs)
+    {
+        $normalized = [];
+
+        foreach ($tabs as $key => $value) {
+            if ($value instanceof Tab) {
+                $normalized[] = $value;
+
+                continue;
+            }
+
+            if (is_string($key) && is_array($value)) {
+                $normalized[] = Block::tab($key, $value);
+
+                continue;
+            }
+
+            throw new InvalidArgumentException('a tab needs a label');
+        }
+
+        $this->tabs = $normalized;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => 'tabs',
+            'value' => array_map(static fn (Tab $tab): array => $tab->toArray(), $this->tabs),
+        ];
+    }
+}

--- a/src/ModalResponse.php
+++ b/src/ModalResponse.php
@@ -85,6 +85,14 @@ class ModalResponse extends ActionResponse
         return self::stack([$block]);
     }
 
+    /**
+     * @param array<mixed> $tabs
+     */
+    public static function tabs(array $tabs): self
+    {
+        return self::stack([Block::tabs($tabs)]);
+    }
+
     public function title(string $title): self
     {
         return $this->setChrome('title', $title);

--- a/tests/Blocks/BlockFactoryTest.php
+++ b/tests/Blocks/BlockFactoryTest.php
@@ -7,6 +7,8 @@ use InvalidArgumentException;
 use Markwalet\NovaModalResponse\Block;
 use Markwalet\NovaModalResponse\Blocks\InlineBlock;
 use Markwalet\NovaModalResponse\Blocks\LinkBlock;
+use Markwalet\NovaModalResponse\Blocks\Tab;
+use Markwalet\NovaModalResponse\Blocks\TabsBlock;
 use Markwalet\NovaModalResponse\Blocks\TextBlock;
 use Markwalet\NovaModalResponse\Tests\TestCase;
 
@@ -63,6 +65,25 @@ class BlockFactoryTest extends TestCase
             Block::text('Hello')->toArray(),
             Block::normalize('Hello')->toArray(),
         );
+    }
+
+    public function test_tab_factory_returns_a_tab_value_object(): void
+    {
+        $tab = Block::tab('Overview', [Block::text('Hi')]);
+
+        $this->assertInstanceOf(Tab::class, $tab);
+        $this->assertSame([
+            'label' => 'Overview',
+            'active' => false,
+            'value' => [['type' => 'text', 'value' => 'Hi']],
+        ], $tab->toArray());
+    }
+
+    public function test_tabs_factory_returns_a_tabs_block(): void
+    {
+        $block = Block::tabs([Block::tab('Overview', [])]);
+
+        $this->assertInstanceOf(TabsBlock::class, $block);
     }
 
     public function test_normalize_rejects_a_non_block_non_string_value(): void

--- a/tests/Blocks/TabsBlockTest.php
+++ b/tests/Blocks/TabsBlockTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Markwalet\NovaModalResponse\Tests\Blocks;
+
+use InvalidArgumentException;
+use Markwalet\NovaModalResponse\Block;
+use Markwalet\NovaModalResponse\Blocks\Tab;
+use Markwalet\NovaModalResponse\Blocks\TabsBlock;
+use Markwalet\NovaModalResponse\Tests\TestCase;
+
+class TabsBlockTest extends TestCase
+{
+    public function test_factory_returns_a_tabs_block_with_inactive_tabs_by_default(): void
+    {
+        $block = Block::tabs([
+            Block::tab('Overview', [Block::text('Hello')]),
+        ]);
+
+        $this->assertInstanceOf(TabsBlock::class, $block);
+        $this->assertSame([
+            'type' => 'tabs',
+            'value' => [
+                [
+                    'label' => 'Overview',
+                    'active' => false,
+                    'value' => [
+                        ['type' => 'text', 'value' => 'Hello'],
+                    ],
+                ],
+            ],
+        ], $block->toArray());
+    }
+
+    public function test_an_empty_tabs_block_renders_an_empty_value_list(): void
+    {
+        $this->assertSame([
+            'type' => 'tabs',
+            'value' => [],
+        ], Block::tabs([])->toArray());
+    }
+
+    public function test_an_empty_tab_panel_is_allowed(): void
+    {
+        $block = Block::tabs([Block::tab('Empty', [])]);
+
+        $this->assertSame([
+            'type' => 'tabs',
+            'value' => [
+                ['label' => 'Empty', 'active' => false, 'value' => []],
+            ],
+        ], $block->toArray());
+    }
+
+    public function test_active_marks_the_tab_as_initially_visible(): void
+    {
+        $tab = Block::tab('Logs', [])->active();
+
+        $this->assertTrue($tab->toArray()['active']);
+    }
+
+    public function test_active_resolves_a_callable_argument(): void
+    {
+        $on = Block::tab('Logs', [])->active(fn (): bool => true);
+        $off = Block::tab('Logs', [])->active(fn (): bool => false);
+
+        $this->assertTrue($on->toArray()['active']);
+        $this->assertFalse($off->toArray()['active']);
+    }
+
+    public function test_active_false_deactivates_the_tab(): void
+    {
+        $tab = Block::tab('Logs', [])->active(false);
+
+        $this->assertFalse($tab->toArray()['active']);
+    }
+
+    public function test_last_active_call_wins(): void
+    {
+        $tab = Block::tab('Logs', [])->active()->active(false);
+
+        $this->assertFalse($tab->toArray()['active']);
+    }
+
+    public function test_string_keyed_array_entry_becomes_a_tab(): void
+    {
+        $block = Block::tabs([
+            'Overview' => [Block::text('Hi')],
+        ]);
+
+        $this->assertSame([
+            'type' => 'tabs',
+            'value' => [
+                [
+                    'label' => 'Overview',
+                    'active' => false,
+                    'value' => [['type' => 'text', 'value' => 'Hi']],
+                ],
+            ],
+        ], $block->toArray());
+    }
+
+    public function test_mixed_array_normalizes_tab_instances_and_string_keyed_entries(): void
+    {
+        $block = Block::tabs([
+            Block::tab('Logs', [Block::text('log line')])->active(),
+            'Overview' => [Block::text('overview text')],
+        ]);
+
+        $this->assertSame([
+            'type' => 'tabs',
+            'value' => [
+                [
+                    'label' => 'Logs',
+                    'active' => true,
+                    'value' => [['type' => 'text', 'value' => 'log line']],
+                ],
+                [
+                    'label' => 'Overview',
+                    'active' => false,
+                    'value' => [['type' => 'text', 'value' => 'overview text']],
+                ],
+            ],
+        ], $block->toArray());
+    }
+
+    public function test_bare_strings_inside_a_tab_are_coerced_to_text_blocks(): void
+    {
+        $block = Block::tabs([Block::tab('Notes', ['Hello'])]);
+
+        $this->assertSame([
+            'type' => 'tabs',
+            'value' => [
+                [
+                    'label' => 'Notes',
+                    'active' => false,
+                    'value' => [['type' => 'text', 'value' => 'Hello']],
+                ],
+            ],
+        ], $block->toArray());
+    }
+
+    public function test_tabs_can_be_nested(): void
+    {
+        $block = Block::tabs([
+            Block::tab('Outer', [
+                Block::tabs([
+                    Block::tab('Inner', [Block::text('Deep')]),
+                ]),
+            ]),
+        ]);
+
+        $this->assertSame([
+            'type' => 'tabs',
+            'value' => [
+                [
+                    'label' => 'Outer',
+                    'active' => false,
+                    'value' => [
+                        [
+                            'type' => 'tabs',
+                            'value' => [
+                                [
+                                    'label' => 'Inner',
+                                    'active' => false,
+                                    'value' => [['type' => 'text', 'value' => 'Deep']],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $block->toArray());
+    }
+
+    public function test_a_bare_array_without_a_string_key_is_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('a tab needs a label');
+
+        Block::tabs([[Block::text('orphan')]]);
+    }
+
+    public function test_a_non_tab_object_is_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('a tab needs a label');
+
+        Block::tabs([Block::text('not a tab')]);
+    }
+
+    public function test_a_scalar_entry_is_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('a tab needs a label');
+
+        Block::tabs(['Overview']);
+    }
+
+    public function test_a_tab_value_object_serializes_without_a_type_key(): void
+    {
+        $tab = new Tab('Logs', [Block::text('hi')]);
+
+        $this->assertArrayNotHasKey('type', $tab->toArray());
+        $this->assertSame(['label', 'active', 'value'], array_keys($tab->toArray()));
+    }
+}

--- a/tests/ModalResponseTest.php
+++ b/tests/ModalResponseTest.php
@@ -96,6 +96,34 @@ class ModalResponseTest extends TestCase
         ModalResponse::stack([42]);
     }
 
+    public function test_tabs_sugar_produces_a_single_tabs_block_stack(): void
+    {
+        $response = ModalResponse::tabs([
+            Block::tab('Overview', [Block::text('Hello')])->active(),
+            'Logs' => [Block::text('log line')],
+        ]);
+
+        $this->assertSame([
+            'blocks' => [
+                [
+                    'type' => 'tabs',
+                    'value' => [
+                        [
+                            'label' => 'Overview',
+                            'active' => true,
+                            'value' => [['type' => 'text', 'value' => 'Hello']],
+                        ],
+                        [
+                            'label' => 'Logs',
+                            'active' => false,
+                            'value' => [['type' => 'text', 'value' => 'log line']],
+                        ],
+                    ],
+                ],
+            ],
+        ], $response['modal']->payload);
+    }
+
     public function test_stack_with_an_array_of_blocks_writes_the_blocks_wire_payload(): void
     {
         $response = ModalResponse::stack([Block::text('hi')]);

--- a/workbench/app/Nova/Actions/ViewTabsAction.php
+++ b/workbench/app/Nova/Actions/ViewTabsAction.php
@@ -35,7 +35,7 @@ class ViewTabsAction extends Action
                 ],
                 'Activity' => [
                     Block::heading('Activity tab'),
-                    Block::code("git log --oneline -5"),
+                    Block::code('git log --oneline -5'),
                 ],
             ]),
             Block::divider(),

--- a/workbench/app/Nova/Actions/ViewTabsAction.php
+++ b/workbench/app/Nova/Actions/ViewTabsAction.php
@@ -21,39 +21,24 @@ class ViewTabsAction extends Action
 
     public function handle(ActionFields $fields, Collection $models): Action|ActionResponse
     {
-        return ModalResponse::stack([
-            Block::heading('String-keyed shorthand')->small(),
-            Block::tabs([
-                'Overview' => [
-                    Block::heading('Overview tab'),
-                    Block::text('Tabs accept a "label => [blocks]" shorthand.'),
-                    Block::badge('Default')->info(),
-                ],
-                'Details' => [
-                    Block::heading('Details tab'),
-                    Block::list(['Item one', 'Item two', 'Item three']),
-                ],
-                'Activity' => [
-                    Block::heading('Activity tab'),
-                    Block::code('git log --oneline -5'),
-                ],
-            ]),
-            Block::divider(),
-            Block::heading('Explicit Block::tab() with active default')->small(),
-            Block::tabs([
-                Block::tab('Draft', [
-                    Block::text('Draft state.'),
-                    Block::badge('Draft')->warning(),
-                ]),
-                Block::tab('Published', [
-                    Block::text('Published state — default active.'),
-                    Block::badge('Published')->success(),
-                ])->active(),
-                Block::tab('Archived', [
-                    Block::text('Archived state.'),
-                    Block::badge('Archived')->danger(),
-                ]),
-            ]),
+        return ModalResponse::tabs([
+            'Overview' => [
+                Block::heading('Overview'),
+                Block::text('Tabs accept a "label => [blocks]" shorthand.'),
+                Block::badge('Default')->info(),
+            ],
+            'Details' => [
+                Block::heading('Details'),
+                Block::list(['Item one', 'Item two', 'Item three']),
+            ],
+            Block::tab('Activity', [
+                Block::heading('Activity'),
+                Block::code('git log --oneline -5'),
+            ])->active(),
+            'Archived' => [
+                Block::heading('Archived'),
+                Block::badge('Archived')->danger(),
+            ],
         ])
             ->title('Demo — tabs block')
             ->closeButton('Close');

--- a/workbench/app/Nova/Actions/ViewTabsAction.php
+++ b/workbench/app/Nova/Actions/ViewTabsAction.php
@@ -27,14 +27,14 @@ class ViewTabsAction extends Action
                 Block::text('Tabs accept a "label => [blocks]" shorthand.'),
                 Block::badge('Default')->info(),
             ],
-            'Details' => [
+            Block::tab('Details', [
                 Block::heading('Details'),
                 Block::list(['Item one', 'Item two', 'Item three']),
-            ],
-            Block::tab('Activity', [
+            ])->active(),
+            'Activity' => [
                 Block::heading('Activity'),
                 Block::code('git log --oneline -5'),
-            ])->active(),
+            ],
             'Archived' => [
                 Block::heading('Archived'),
                 Block::badge('Archived')->danger(),

--- a/workbench/app/Nova/Actions/ViewTabsAction.php
+++ b/workbench/app/Nova/Actions/ViewTabsAction.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Nova\Actions;
+
+use Illuminate\Support\Collection;
+use Laravel\Nova\Actions\Action;
+use Laravel\Nova\Actions\ActionResponse;
+use Laravel\Nova\Fields\ActionFields;
+use Markwalet\NovaModalResponse\Block;
+use Markwalet\NovaModalResponse\ModalResponse;
+
+class ViewTabsAction extends Action
+{
+    public $name = 'View tabs';
+
+    public $withoutConfirmation = true;
+
+    public $showInline = true;
+
+    public function handle(ActionFields $fields, Collection $models): Action|ActionResponse
+    {
+        return ModalResponse::stack([
+            Block::heading('String-keyed shorthand')->small(),
+            Block::tabs([
+                'Overview' => [
+                    Block::heading('Overview tab'),
+                    Block::text('Tabs accept a "label => [blocks]" shorthand.'),
+                    Block::badge('Default')->info(),
+                ],
+                'Details' => [
+                    Block::heading('Details tab'),
+                    Block::list(['Item one', 'Item two', 'Item three']),
+                ],
+                'Activity' => [
+                    Block::heading('Activity tab'),
+                    Block::code("git log --oneline -5"),
+                ],
+            ]),
+            Block::divider(),
+            Block::heading('Explicit Block::tab() with active default')->small(),
+            Block::tabs([
+                Block::tab('Draft', [
+                    Block::text('Draft state.'),
+                    Block::badge('Draft')->warning(),
+                ]),
+                Block::tab('Published', [
+                    Block::text('Published state — default active.'),
+                    Block::badge('Published')->success(),
+                ])->active(),
+                Block::tab('Archived', [
+                    Block::text('Archived state.'),
+                    Block::badge('Archived')->danger(),
+                ]),
+            ]),
+        ])
+            ->title('Demo — tabs block')
+            ->closeButton('Close');
+    }
+}

--- a/workbench/app/Nova/User.php
+++ b/workbench/app/Nova/User.php
@@ -17,6 +17,7 @@ use Laravel\Nova\Panel;
 use Laravel\Nova\ResourceTool;
 use Workbench\App\Nova\Actions\ViewBladeViewAction;
 use Workbench\App\Nova\Actions\ViewMarkdownAction;
+use Workbench\App\Nova\Actions\ViewTabsAction;
 use Workbench\App\Nova\Actions\ViewTextStackAction;
 use Workbench\App\Nova\Actions\ViewWithoutHighlightingAction;
 
@@ -116,6 +117,7 @@ class User extends Resource
             new ViewBladeViewAction,
             new ViewWithoutHighlightingAction,
             new ViewMarkdownAction,
+            new ViewTabsAction,
         ];
     }
 }


### PR DESCRIPTION
## Summary

- New `tabs` block: block-level container with a header bar showing exactly one nested stack at a time.
- `Tab` value object (label + normalized child stack + `->active(bool|callable)`), explicitly **not** a `Renderable` — its `toArray()` carries `label`/`active`/`value` and no `type` key.
- `TabsBlock` (`Renderable`, not `Inlineable`) with `Block::tab()`/`Block::tabs()` factories and `ModalResponse::tabs()` sugar. `Block::tabs()` normalizes `Tab` passthrough, `string => array` to `Block::tab()`, and otherwise throws `InvalidArgumentException("a tab needs a label")`.
- `TabsBlock.vue` reuses Nova's own `tab-group`/`tab-menu`/`tab-item`/`tab-card` CSS classes (no `@headlessui/vue`), self-managed active index, initial active = last `active === true` else `0`. Registered under `tabs` in `blockComponents.js`.
- Glossary: `Tabs block` and `Tab` entries added to `CONTEXT.md`. No ADR (follows collapsible pattern).

Closes #67

## Test plan

- [x] `vendor/bin/pint --test`
- [x] `vendor/bin/phpstan analyse --no-progress --memory-limit=1G`
- [x] `vendor/bin/phpunit` (126 tests pass)
- [ ] Manual: render a tabs block in the testbench app, confirm header bar styling, active-tab switching, empty-tabs/empty-panel handling, and nested tabs.