### PR TITLE
Reload resource view after a successful action dispatch

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -65,7 +65,7 @@ How a link block is rendered: `link` (the implicit one — bold, primary-coloure
 _Avoid_: link variant, link style, link kind
 
 **Action block**:
-An inline atom that renders a button which, when clicked, dispatches a Nova action. Built in PHP via `Block::action(MyAction::class)` (label defaults to the action's `name()`) or `Block::action('Custom label', MyAction::class)`. Fieldless by construction — serializing throws if the target action declares `fields()`, with a message pointing to the planned form block (`Block::form`). Atoms (Inlineable), so a row of buttons composes inside an inline group. Carries the target action's **uriKey** and the **origin context** (resourceName + selected resource ids, captured server-side at serialize time). A successful dispatch always closes the current modal: a modal response replaces it (close-then-open, one modal at a time); a non-modal response (toast/redirect/download/openInNewTab) closes it after Nova's standard handling. A failed dispatch surfaces an error and leaves the modal open so the user can retry.
+An inline atom that renders a button which, when clicked, dispatches a Nova action. Built in PHP via `Block::action(MyAction::class)` (label defaults to the action's `name()`) or `Block::action('Custom label', MyAction::class)`. Fieldless by construction — serializing throws if the target action declares `fields()`, with a message pointing to the planned form block (`Block::form`). Atoms (Inlineable), so a row of buttons composes inside an inline group. Carries the target action's **uriKey** and the **origin context** (resourceName + selected resource ids, captured server-side at serialize time). A successful dispatch always closes the current modal: a modal response replaces it (close-then-open, one modal at a time); a non-modal response (toast/redirect/download/openInNewTab) closes it after Nova's standard handling. A failed dispatch surfaces an error and leaves the modal open so the user can retry. A successful dispatch also reloads the underlying resource view (see **Resource reload**); a failed dispatch does not.
 _Avoid_: button block, action button, dispatcher
 
 **Dispatch**:
@@ -75,6 +75,10 @@ _Avoid_: invoke, execute, fire, call
 **Intercept**:
 The Vue-side choice to drive the action dispatch itself rather than delegating to Nova's action runner. The action block POSTs to Nova's endpoint, owns the response, and applies the package's close-then-open rule — Nova's runner just stacks modals, which the package deliberately does not.
 _Avoid_: hijack, override, take over
+
+**Resource reload**:
+Restores Nova's native "the resource view refreshes after an action runs" behavior, which **interception** otherwise drops: bypassing Nova's runner means nothing emits the action-completed signal the parent Index/Lens listens to. After a successful **dispatch**, the action block emits Nova's `refresh-resources` event itself so the underlying resource view reloads to reflect a mutating action. On by default; opt out per-block with `->withoutReload()` for read-only / preview actions. Travels on the wire as `reload` (boolean, always emitted). A failed dispatch never reloads. Fires regardless of whether the response was a modal replace or a non-modal toast/redirect/download.
+_Avoid_: refresh, rerender, requery
 
 **Origin context**:
 The parent modal's resource (`resourceName` — the resource URI key) and selected resource ids (`resources`), captured server-side when an action block is serialized and shipped on the wire. The Vue side uses it to rebuild the action endpoint and form payload on click, so every dispatch runs against the same resource + selection the modal opened against. Outside an HTTP request (e.g. in serialization tests), resourceName falls back to `null` and resources to an empty array.

--- a/resources/js/components/ActionBlock.vue
+++ b/resources/js/components/ActionBlock.vue
@@ -74,6 +74,7 @@ export default {
                 })
 
                 this.handleResponse(response.data, response.headers)
+                this.reloadResourceView()
             } catch (error) {
                 this.surfaceError(error)
             } finally {
@@ -156,6 +157,19 @@ export default {
             if (data && data.message) {
                 Nova.success(data.message)
             }
+        },
+
+        reloadResourceView() {
+            // Restore Nova's native "the resource view refreshes after an
+            // action runs" behavior. The interception (see `dispatchAction`)
+            // bypasses Nova's runner, which is what otherwise emits this on
+            // the Index/Lens view. `block.reload === false` opts out for
+            // read-only / preview actions (PHP `->withoutReload()`).
+            if (this.block.reload === false) {
+                return
+            }
+
+            Nova.$emit('refresh-resources')
         },
 
         surfaceError(error) {

--- a/src/Blocks/ActionBlock.php
+++ b/src/Blocks/ActionBlock.php
@@ -29,6 +29,13 @@ class ActionBlock implements Inlineable, Renderable
     private readonly string $actionClass;
 
     /**
+     * Whether a successful dispatch should reload the underlying resource
+     * view. Defaults to true to mirror Nova's native action behavior; flip
+     * to false via {@see withoutReload()} for read-only/preview actions.
+     */
+    private bool $reload = true;
+
+    /**
      * @param class-string<Action> $actionClass
      */
     public function __construct(
@@ -45,6 +52,17 @@ class ActionBlock implements Inlineable, Renderable
     }
 
     /**
+     * Suppress the post-dispatch resource view reload. Use for actions that
+     * don't mutate the underlying data (read-only / preview).
+     */
+    public function withoutReload(): self
+    {
+        $this->reload = false;
+
+        return $this;
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function toArray(): array
@@ -57,6 +75,7 @@ class ActionBlock implements Inlineable, Renderable
             'type' => 'action',
             'value' => (string) ($this->label ?? $action->name()),
             'action' => $action->uriKey(),
+            'reload' => $this->reload,
             ...$this->originContext(),
         ];
     }

--- a/tests/Blocks/ActionBlockTest.php
+++ b/tests/Blocks/ActionBlockTest.php
@@ -61,6 +61,27 @@ class ActionBlockTest extends TestCase
         $this->assertSame('fake-fieldless', $payload['action']);
     }
 
+    public function test_serialization_defaults_reload_to_true(): void
+    {
+        $payload = Block::action(FakeFieldlessAction::class)->toArray();
+
+        $this->assertTrue($payload['reload']);
+    }
+
+    public function test_without_reload_flips_the_reload_flag(): void
+    {
+        $payload = Block::action(FakeFieldlessAction::class)->withoutReload()->toArray();
+
+        $this->assertFalse($payload['reload']);
+    }
+
+    public function test_without_reload_returns_the_block_for_chaining(): void
+    {
+        $block = Block::action(FakeFieldlessAction::class);
+
+        $this->assertSame($block, $block->withoutReload());
+    }
+
     public function test_serialization_omits_disposition_and_stay_open_fields(): void
     {
         $payload = Block::action(FakeFieldlessAction::class)->toArray();


### PR DESCRIPTION
## Summary

Restores Nova's native "the resource view refreshes after an action runs" behavior, which interception (the action block's deliberate bypass of Nova's runner) otherwise drops. Without this, mutating actions complete silently and the parent Index/Detail/Lens view goes stale until the user reloads manually.

- **PHP**: `ActionBlock` gains a `reload` flag (default `true`) serialized on the wire, plus a fluent `->withoutReload()` to opt out per block for read-only / preview actions.
- **Vue**: After a successful dispatch (modal response *or* non-modal), emits Nova's global `refresh-resources` event — the same one Index/Lens listen to. Skips the emit when `block.reload === false`. Never fires on a failed dispatch.
- **CONTEXT.md**: gains a `Resource reload` glossary entry; the action block entry references the new behavior.

**Base is `v2-action-block`**, not `v2` — this stacks on the freshly-merged action block (#85, closes #70).

**Stacking note**: sibling ticket #72 (confirmation guard) is in flight in parallel and also touches the action block. Before this PR is merged, it should be rebased onto `v2-action-confirm` (#72's branch) so the two land in sequence.

Closes #73

## Test plan

- [x] `vendor/bin/pint --test`
- [x] `vendor/bin/phpstan analyse --no-progress --memory-limit=1G`
- [x] `vendor/bin/phpunit` — 123 tests pass
- [ ] Manual: trigger a mutating action from inside the modal on an Index view — the table refreshes after dispatch.
- [ ] Manual: same action with `->withoutReload()` — table does not refresh.
- [ ] Manual: failed dispatch (e.g. action throws) — modal stays open, no refresh.