### PR TITLE
Widen collapsible to accept a single block or an array

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -118,9 +118,9 @@ final class Block
     }
 
     /**
-     * @param array<int, Renderable|string|StringableInterface> $blocks
+     * @param Renderable|string|StringableInterface|array<int, Renderable|string|StringableInterface> $blocks
      */
-    public static function collapsible(string $header, array $blocks): CollapsibleBlock
+    public static function collapsible(string $header, mixed $blocks): CollapsibleBlock
     {
         return new CollapsibleBlock($header, $blocks);
     }

--- a/src/Blocks/CollapsibleBlock.php
+++ b/src/Blocks/CollapsibleBlock.php
@@ -2,6 +2,7 @@
 
 namespace Markwalet\NovaModalResponse\Blocks;
 
+use Illuminate\Support\Arr;
 use Markwalet\NovaModalResponse\Block;
 use Stringable;
 
@@ -13,13 +14,13 @@ class CollapsibleBlock implements Renderable
     private readonly array $blocks;
 
     /**
-     * @param array<int, Renderable|string|Stringable> $blocks
+     * @param Renderable|string|Stringable|array<int, Renderable|string|Stringable> $blocks
      */
-    public function __construct(private readonly string $header, array $blocks)
+    public function __construct(private readonly string $header, mixed $blocks)
     {
         $this->blocks = array_map(
             static fn (mixed $block): Renderable => Block::normalize($block),
-            array_values($blocks),
+            array_values(Arr::wrap($blocks)),
         );
     }
 

--- a/tests/Blocks/CollapsibleBlockTest.php
+++ b/tests/Blocks/CollapsibleBlockTest.php
@@ -124,11 +124,47 @@ class CollapsibleBlockTest extends TestCase
         ], Block::collapsible('Details', [])->toArray());
     }
 
+    public function test_a_single_block_wraps_to_a_one_element_value_list(): void
+    {
+        $block = Block::collapsible('Details', Block::text('hi'));
+
+        $this->assertSame([
+            'type' => 'collapsible',
+            'header' => 'Details',
+            'expanded' => false,
+            'value' => [
+                ['type' => 'text', 'value' => 'hi'],
+            ],
+        ], $block->toArray());
+    }
+
+    public function test_a_single_bare_string_is_coerced_to_one_text_block(): void
+    {
+        $block = Block::collapsible('Details', 'hi');
+
+        $this->assertSame([
+            'type' => 'collapsible',
+            'header' => 'Details',
+            'expanded' => false,
+            'value' => [
+                ['type' => 'text', 'value' => 'hi'],
+            ],
+        ], $block->toArray());
+    }
+
     public function test_a_non_block_non_string_child_is_rejected(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Blocks must be Block instances or strings.');
 
         Block::collapsible('Details', [42]);
+    }
+
+    public function test_a_single_non_block_non_string_child_is_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Blocks must be Block instances or strings.');
+
+        Block::collapsible('Details', 42);
     }
 }


### PR DESCRIPTION
Closes #90.

Widens `Block::collapsible($header, $blocks)` and the `CollapsibleBlock` constructor so `$blocks` accepts a single block **or** an array. Internally `Arr::wrap($blocks)` collapses the single-vs-array distinction before the existing `Block::normalize` pass. Authoring-side sugar only — wire format is unchanged (a single block serializes to a one-element `value` list) and `CollapsibleBlock.vue` is untouched. Scope is `collapsible` only.

### Note on the type signature
The ticket specified the param type as `Renderable|string|Stringable|array` *and* required a bare `42` to throw `InvalidArgumentException` via `normalize`. Those are mutually exclusive under this package's coercive typing (no `declare(strict_types=1)`): with `string` in the union, PHP coerces a scalar `42` to `"42"` before the body runs, so it would silently become a text block rather than throw.

To keep both `42` and `[42]` routing through the same `normalize` logic (consistent rejection), the param is typed `mixed` with the union preserved in the docblock for IDEs.

### What changed
- `Block::collapsible` factory and `CollapsibleBlock` constructor accept a single block or an array
- Single `Renderable` → one-element `value`; single bare string → one text block
- Single invalid scalar (`42`) throws the same `InvalidArgumentException` as `[42]`
- Existing array / empty-array / `[42]` behaviours unchanged

### QA
- `vendor/bin/pint --test` ✅
- `vendor/bin/phpstan analyse` ✅
- `vendor/bin/phpunit` ✅ (153 tests, including 3 new cases)

No CONTEXT.md/ADR changes — authoring affordance, not a domain-language shift.